### PR TITLE
Ensure there are stack traces on all custom error objects.

### DIFF
--- a/src/errors/InvalidJsonError.js
+++ b/src/errors/InvalidJsonError.js
@@ -5,5 +5,8 @@ module.exports = class InvalidJsonError extends Error {
         this.jsonString = jsonString
         this.parseError = parseError
         this.streamMessage = streamMessage
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor)
+        }
     }
 }

--- a/src/errors/UnsupportedTypeError.js
+++ b/src/errors/UnsupportedTypeError.js
@@ -2,6 +2,8 @@ module.exports = class UnsupportedTypeError extends Error {
     constructor(type, message) {
         super(`Unsupported type: ${type}, message: ${message}`)
         this.type = type
-        this.message = message
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor)
+        }
     }
 }

--- a/src/errors/UnsupportedVersionError.js
+++ b/src/errors/UnsupportedVersionError.js
@@ -2,6 +2,8 @@ module.exports = class UnsupportedVersionError extends Error {
     constructor(version, message) {
         super(`Unsupported version: ${version}, message: ${message}`)
         this.version = version
-        this.message = message
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor)
+        }
     }
 }

--- a/src/errors/ValidationError.js
+++ b/src/errors/ValidationError.js
@@ -1,1 +1,8 @@
-module.exports = class ValidationError extends Error {}
+module.exports = class ValidationError extends Error {
+    constructor(...args) {
+        super(...args)
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor)
+        }
+    }
+}


### PR DESCRIPTION
We've been scratching our heads for the past few weeks as to why some errors we were seeing in Sentry had no stack traces, specifically errors coming out of this library. I suspect this is the culprit.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Custom_Error_Types

![image](https://user-images.githubusercontent.com/43438/59244045-71b79700-8c45-11e9-9ade-fe6c9b3dc25c.png)

cc @fonty1