### PR TITLE
split in 2 timeouts

### DIFF
--- a/test/unit/utils/OrderedMsgChain.test.js
+++ b/test/unit/utils/OrderedMsgChain.test.js
@@ -118,7 +118,7 @@ describe('OrderedMsgChain', () => {
             assert.strictEqual(publisherId, 'publisherId')
             assert.strictEqual(msgChainId, 'msgChainId')
             counter += 1
-        }, 100)
+        }, 100, 100)
         util.on('error', (e) => {
             assert.strictEqual(e.message, 'Failed to fill gap between [1,1] and [2,0] for publisherId-msgChainId'
                 + ` after ${OrderedMsgChain.MAX_GAP_REQUESTS} trials`)


### PR DESCRIPTION
As discussed with @hpihkala, the first timeout and the next ones are different:
- The first timeout is the propagation delay.
- The next timeouts are resend delays.

So there needs to be 2 parameters to set these timeouts instead of just one.