### PR TITLE
Fix gap clearing issue

### DIFF
--- a/src/utils/OrderedMsgChain.js
+++ b/src/utils/OrderedMsgChain.js
@@ -117,6 +117,8 @@ export default class OrderedMsgChain extends EventEmitter {
         } else {
             this.emit('error', new GapFillFailedError(from, to, this.publisherId, this.msgChainId, MAX_GAP_REQUESTS))
             this.clearGap()
+            this.lastReceivedMsgRef = null
+            this._checkQueue()
         }
     }
 }


### PR DESCRIPTION
There is an issue in which after `MAX_GAP_REQUESTS` re-tries of gap handling the `OrderingMsgChain` instance still tries to gap fill the same gap. 

Setting `this.lastReceivedMsgRef = null` after `MAX_GAP_REQUESTS` solves this because condition `_isNextMessage(msg) === true` will hold on next message `msg` and thus processing will continue (When the condition is false, the message is queued and gap handling of the _same_ gap is started.) 

I added `this._checkQueue()` right after setting the variable to null to ensure we handle any messages from queue. In a previous solution I left this out, meaning that `OrderingMsgChain` would continue from most newest received message and basically ignore whatever was in the queue. However, I think the intent is to handle the messages from queue?