### PR TITLE
Add validation to message constructors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "2.2.15",
+  "version": "3.0.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "2.2.15",
+  "version": "3.0.0-0",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/src/protocol/control_layer/ResendResponsePayload.js
+++ b/src/protocol/control_layer/ResendResponsePayload.js
@@ -1,11 +1,10 @@
+import { validateIsNotEmptyString } from '../../utils/validations'
 import StreamAndPartition from './StreamAndPartition'
 
 export default class ResendResponsePayload extends StreamAndPartition {
     constructor(streamId, streamPartition, subId) {
         super(streamId, streamPartition)
-        if (subId == null) {
-            throw new Error('Subscription id cannot be null!')
-        }
+        validateIsNotEmptyString('subId', subId)
         this.subId = subId
     }
 

--- a/src/protocol/control_layer/StreamAndPartition.js
+++ b/src/protocol/control_layer/StreamAndPartition.js
@@ -1,15 +1,10 @@
 import { ensureParsed } from '../../utils/ParseUtil'
-import ValidationError from '../../errors/ValidationError'
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../utils/validations'
 
 export default class StreamAndPartition {
     constructor(streamId, streamPartition) {
-        if (!streamId) {
-            throw new ValidationError('Stream ID not given!')
-        }
-        if (!streamPartition == null) {
-            throw new ValidationError('Stream partition not given!')
-        }
-
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
         this.streamId = streamId
         this.streamPartition = streamPartition
     }

--- a/src/protocol/control_layer/broadcast_message/BroadcastMessageV0.js
+++ b/src/protocol/control_layer/broadcast_message/BroadcastMessageV0.js
@@ -1,3 +1,4 @@
+import { validateIsNotNullOrUndefined } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import StreamMessageFactory from '../../message_layer/StreamMessageFactory'
 import ControlMessage from '../ControlMessage'
@@ -9,6 +10,7 @@ const VERSION = 0
 export default class BroadcastMessageV0 extends BroadcastMessage {
     constructor(streamMessage) {
         super(VERSION)
+        validateIsNotNullOrUndefined('streamMessage', streamMessage)
         this.payload = streamMessage
     }
 

--- a/src/protocol/control_layer/broadcast_message/BroadcastMessageV1.js
+++ b/src/protocol/control_layer/broadcast_message/BroadcastMessageV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotNullOrUndefined } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import StreamMessageFactory from '../../message_layer/StreamMessageFactory'
@@ -9,6 +10,7 @@ const VERSION = 1
 export default class BroadcastMessageV1 extends BroadcastMessage {
     constructor(streamMessage) {
         super(VERSION)
+        validateIsNotNullOrUndefined('streamMessage', streamMessage)
         this.streamMessage = streamMessage
     }
 

--- a/src/protocol/control_layer/error_response/ErrorResponseV0.js
+++ b/src/protocol/control_layer/error_response/ErrorResponseV0.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import ErrorResponse from './ErrorResponse'
@@ -9,6 +10,7 @@ const VERSION = 0
 export default class ErrorResponseV0 extends ErrorResponse {
     constructor(errorMessage) {
         super(VERSION)
+        validateIsNotEmptyString('errorMessage', errorMessage)
         this.payload = new ErrorPayload(errorMessage)
     }
 

--- a/src/protocol/control_layer/error_response/ErrorResponseV1.js
+++ b/src/protocol/control_layer/error_response/ErrorResponseV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import ErrorResponse from './ErrorResponse'
@@ -8,6 +9,7 @@ const VERSION = 1
 export default class ErrorResponseV1 extends ErrorResponse {
     constructor(errorMessage) {
         super(VERSION)
+        validateIsNotEmptyString('errorMessage', errorMessage)
         this.errorMessage = errorMessage
     }
 

--- a/src/protocol/control_layer/publish_request/PublishRequestV0.js
+++ b/src/protocol/control_layer/publish_request/PublishRequestV0.js
@@ -1,3 +1,9 @@
+import {
+    validateIsInteger,
+    validateIsNotEmptyString,
+    validateIsNotNullOrUndefined,
+    validateIsString,
+} from '../../../utils/validations'
 import * as TimestampUtil from '../../../utils/TimestampUtil'
 import ValidationError from '../../../errors/ValidationError'
 import StreamMessageV30 from '../../message_layer/StreamMessageV30'
@@ -11,18 +17,25 @@ const VERSION = 0
 export default class PublishRequestV0 extends PublishRequest {
     constructor(streamId, apiKey, sessionToken, content, timestamp, partitionKey, publisherAddress, signatureType, signature) {
         super(VERSION, sessionToken)
-        this.apiKey = apiKey
-        this.streamId = streamId
 
-        if (!content) {
-            throw new ValidationError('No content given!')
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsString('apiKey', apiKey, true)
+        validateIsString('sessionToken', sessionToken, true)
+        validateIsNotNullOrUndefined('content', content)
+        validateIsString('partitionKey', partitionKey, true)
+        validateIsString('publisherAddress', publisherAddress, true)
+        validateIsInteger('signatureType', signatureType, true)
+        validateIsString('signature', signature, true)
+        if (apiKey == null && sessionToken == null) {
+            throw new ValidationError('Both apiKey and sessionToken cannot be null/undefined.')
         }
-        this.content = content
 
+        this.streamId = streamId
+        this.apiKey = apiKey
+        this.content = content
         if (timestamp) {
             this.timestamp = TimestampUtil.parse(timestamp)
         }
-
         this.partitionKey = partitionKey
         this.publisherAddress = publisherAddress
         this.signatureType = signatureType

--- a/src/protocol/control_layer/publish_request/PublishRequestV1.js
+++ b/src/protocol/control_layer/publish_request/PublishRequestV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotNullOrUndefined } from '../../../utils/validations'
 import StreamMessageFactory from '../../message_layer/StreamMessageFactory'
 import ControlMessage from '../ControlMessage'
 import PublishRequest from './PublishRequest'
@@ -7,6 +8,7 @@ const VERSION = 1
 export default class PublishRequestV1 extends PublishRequest {
     constructor(streamMessage, sessionToken) {
         super(VERSION, sessionToken)
+        validateIsNotNullOrUndefined('streamMessage', streamMessage)
         this.streamMessage = streamMessage
     }
 

--- a/src/protocol/control_layer/resend_request/ResendFromRequestV1.js
+++ b/src/protocol/control_layer/resend_request/ResendFromRequestV1.js
@@ -1,3 +1,4 @@
+import { validateIsString, validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 import MessageRef from '../../message_layer/MessageRef'
 import ResendFromRequest from './ResendFromRequest'
@@ -7,6 +8,14 @@ const VERSION = 1
 export default class ResendFromRequestV1 extends ResendFromRequest {
     constructor(streamId, streamPartition, subId, msgRefArgsArray, publisherId, msgChainId, sessionToken) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+        validateIsString('publisherId', publisherId, true)
+        validateIsString('msgChainId', msgChainId, true)
+        validateIsString('sessionToken', sessionToken, true)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.subId = subId

--- a/src/protocol/control_layer/resend_request/ResendLastRequestV1.js
+++ b/src/protocol/control_layer/resend_request/ResendLastRequestV1.js
@@ -1,3 +1,4 @@
+import { validateIsString, validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 import ResendLastRequest from './ResendLastRequest'
 
@@ -6,6 +7,13 @@ const VERSION = 1
 export default class ResendLastRequestV1 extends ResendLastRequest {
     constructor(streamId, streamPartition, subId, numberLast, sessionToken) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+        validateIsNotNegativeInteger('numberLast', numberLast)
+        validateIsString('sessionToken', sessionToken, true)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.subId = subId

--- a/src/protocol/control_layer/resend_request/ResendRangeRequestV1.js
+++ b/src/protocol/control_layer/resend_request/ResendRangeRequestV1.js
@@ -1,3 +1,4 @@
+import { validateIsString, validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 import ValidationError from '../../../errors/ValidationError'
 import MessageRef from '../../message_layer/MessageRef'
@@ -8,6 +9,14 @@ const VERSION = 1
 export default class ResendRangeRequestV1 extends ResendRangeRequest {
     constructor(streamId, streamPartition, subId, fromMsgRefArgsArray, toMsgRefArgsArray, publisherId, msgChainId, sessionToken) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+        validateIsString('publisherId', publisherId, true)
+        validateIsString('msgChainId', msgChainId, true)
+        validateIsString('sessionToken', sessionToken, true)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.subId = subId

--- a/src/protocol/control_layer/resend_request/ResendRequestV0.js
+++ b/src/protocol/control_layer/resend_request/ResendRequestV0.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString, validateIsNotNegativeInteger, validateIsString } from '../../../utils/validations'
 import ValidationError from '../../../errors/ValidationError'
 import ControlMessage from '../ControlMessage'
 
@@ -7,18 +8,20 @@ const VERSION = 0
 export default class ResendRequestV0 extends ControlMessage {
     constructor(streamId, streamPartition, subId, resendOptions, apiKey, sessionToken) {
         super(VERSION, TYPE)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+        validateIsString('apiKey', apiKey, true)
+        validateIsString('sessionToken', sessionToken, true)
+        if (!resendOptions.resend_all && !resendOptions.resend_last
+            && resendOptions.resend_from == null && resendOptions.resend_from_time == null) {
+            throw new ValidationError('Invalid resend options!')
+        }
+
         this.streamId = streamId
         this.apiKey = apiKey
         this.sessionToken = sessionToken
-
-        if (!resendOptions.resend_all && !resendOptions.resend_last
-          && resendOptions.resend_from == null && resendOptions.resend_from_time == null) {
-            throw new ValidationError('Invalid resend options!')
-        }
-        if (!subId) {
-            throw new ValidationError('Subscription ID not given!')
-        }
-
         this.streamPartition = streamPartition
         this.subId = subId
         this.resendOptions = resendOptions

--- a/src/protocol/control_layer/resend_response_no_resend/ResendResponseNoResendV1.js
+++ b/src/protocol/control_layer/resend_response_no_resend/ResendResponseNoResendV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import ResendResponseNoResend from './ResendResponseNoResend'
@@ -8,6 +9,11 @@ const VERSION = 1
 export default class ResendResponseNoResendV1 extends ResendResponseNoResend {
     constructor(streamId, streamPartition, subId) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.subId = subId

--- a/src/protocol/control_layer/resend_response_resending/ResendResponseResendingV1.js
+++ b/src/protocol/control_layer/resend_response_resending/ResendResponseResendingV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import ResendResponseResending from './ResendResponseResending'
@@ -8,6 +9,11 @@ const VERSION = 1
 export default class ResendResponseResendingV1 extends ResendResponseResending {
     constructor(streamId, streamPartition, subId) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.subId = subId

--- a/src/protocol/control_layer/resend_response_resent/ResendResponseResentV1.js
+++ b/src/protocol/control_layer/resend_response_resent/ResendResponseResentV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import ResendResponseResent from './ResendResponseResent'
@@ -8,6 +9,11 @@ const VERSION = 1
 export default class ResendResponseResentV1 extends ResendResponseResent {
     constructor(streamId, streamPartition, subId) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotEmptyString('subId', subId)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.subId = subId

--- a/src/protocol/control_layer/subscribe_request/SubscribeRequest.js
+++ b/src/protocol/control_layer/subscribe_request/SubscribeRequest.js
@@ -1,4 +1,4 @@
-import ValidationError from '../../../errors/ValidationError'
+import { validateIsNotEmptyString, validateIsNotNegativeInteger, validateIsString } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 
 const TYPE = 9
@@ -9,10 +9,12 @@ export default class SubscribeRequest extends ControlMessage {
             throw new TypeError('SubscribeRequest is abstract.')
         }
         super(version, TYPE)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsString('sessionToken', sessionToken, true)
+
         this.streamId = streamId
-        if (streamPartition == null) {
-            throw new ValidationError('Stream partition not given!')
-        }
         this.streamPartition = streamPartition
         this.sessionToken = sessionToken
     }

--- a/src/protocol/control_layer/subscribe_request/SubscribeRequestV0.js
+++ b/src/protocol/control_layer/subscribe_request/SubscribeRequestV0.js
@@ -1,3 +1,4 @@
+import { validateIsString } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import SubscribeRequest from './SubscribeRequest'
@@ -9,6 +10,7 @@ const VERSION = 0
 export default class SubscribeRequestV0 extends SubscribeRequest {
     constructor(streamId, streamPartition = 0, apiKey, sessionToken) {
         super(VERSION, streamId, streamPartition, sessionToken)
+        validateIsString('apiKey', apiKey, true)
         this.apiKey = apiKey
     }
 

--- a/src/protocol/control_layer/subscribe_response/SubscribeResponseV1.js
+++ b/src/protocol/control_layer/subscribe_response/SubscribeResponseV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import SubscribeResponse from './SubscribeResponse'
@@ -8,6 +9,10 @@ const VERSION = 1
 export default class SubscribeResponseV1 extends SubscribeResponse {
     constructor(streamId, streamPartition = 0) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
     }

--- a/src/protocol/control_layer/unicast_message/UnicastMessage.js
+++ b/src/protocol/control_layer/unicast_message/UnicastMessage.js
@@ -1,3 +1,4 @@
+import { validateIsNotEmptyString } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 
 const TYPE = 1
@@ -8,6 +9,7 @@ export default class UnicastMessage extends ControlMessage {
             throw new TypeError('UnicastMessage is abstract.')
         }
         super(version, TYPE)
+        validateIsNotEmptyString('subId', subId)
         this.subId = subId
     }
 

--- a/src/protocol/control_layer/unicast_message/UnicastMessageV0.js
+++ b/src/protocol/control_layer/unicast_message/UnicastMessageV0.js
@@ -1,3 +1,4 @@
+import { validateIsNotNullOrUndefined } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import StreamMessageFactory from '../../message_layer/StreamMessageFactory'
@@ -9,6 +10,7 @@ const VERSION = 0
 export default class UnicastMessageV0 extends UnicastMessage {
     constructor(streamMessage, subId) {
         super(VERSION, subId)
+        validateIsNotNullOrUndefined('streamMessage', streamMessage)
         this.payload = streamMessage
     }
 

--- a/src/protocol/control_layer/unicast_message/UnicastMessageV1.js
+++ b/src/protocol/control_layer/unicast_message/UnicastMessageV1.js
@@ -1,3 +1,4 @@
+import { validateIsNotNullOrUndefined } from '../../../utils/validations'
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
 import ControlMessage from '../ControlMessage'
 import StreamMessageFactory from '../../message_layer/StreamMessageFactory'
@@ -9,6 +10,7 @@ const VERSION = 1
 export default class UnicastMessageV1 extends UnicastMessage {
     constructor(subId, streamMessage) {
         super(VERSION, subId)
+        validateIsNotNullOrUndefined('streamMessage', streamMessage)
         this.streamMessage = streamMessage
     }
 

--- a/src/protocol/control_layer/unsubscribe_request/UnsubscribeRequest.js
+++ b/src/protocol/control_layer/unsubscribe_request/UnsubscribeRequest.js
@@ -1,4 +1,4 @@
-import ValidationError from '../../../errors/ValidationError'
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 
 const TYPE = 10
@@ -9,10 +9,11 @@ export default class UnsubscribeRequest extends ControlMessage {
             throw new TypeError('UnSubscribeRequest is abstract.')
         }
         super(version, TYPE)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+
         this.streamId = streamId
-        if (streamPartition == null) {
-            throw new ValidationError('Stream partition not given!')
-        }
         this.streamPartition = streamPartition
     }
 

--- a/src/protocol/control_layer/unsubscribe_response/UnsubscribeResponseV1.js
+++ b/src/protocol/control_layer/unsubscribe_response/UnsubscribeResponseV1.js
@@ -1,4 +1,5 @@
 import UnsupportedVersionError from '../../../errors/UnsupportedVersionError'
+import { validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../../utils/validations'
 import ControlMessage from '../ControlMessage'
 import UnsubscribeResponse from './UnsubscribeResponse'
 import UnsubscribeResponseV0 from './UnsubscribeResponseV0'
@@ -8,6 +9,10 @@ const VERSION = 1
 export default class UnsubscribeResponseV1 extends UnsubscribeResponse {
     constructor(streamId, streamPartition = 0) {
         super(VERSION)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
     }

--- a/src/protocol/message_layer/MessageID.js
+++ b/src/protocol/message_layer/MessageID.js
@@ -1,23 +1,14 @@
+import { validateIsString, validateIsNotEmptyString, validateIsNotNegativeInteger } from '../../utils/validations'
+
 export default class MessageID {
     constructor(streamId, streamPartition, timestamp, sequenceNumber, publisherId, msgChainId) {
-        if (streamId == null) {
-            throw new Error('streamId must be defined!')
-        }
-        if (streamPartition == null) {
-            throw new Error('streamPartition must be defined!')
-        }
-        if (timestamp == null) {
-            throw new Error('timestamp must be defined!')
-        }
-        if (sequenceNumber == null) {
-            throw new Error('sequenceNumber must be defined!')
-        }
-        if (publisherId == null) {
-            throw new Error('publisherId must be defined!')
-        }
-        if (msgChainId == null) {
-            throw new Error('msgChainId must be defined!')
-        }
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition)
+        validateIsNotNegativeInteger('timestamp', timestamp)
+        validateIsNotNegativeInteger('sequenceNumber', sequenceNumber)
+        validateIsString('publisherId', publisherId)
+        validateIsString('msgChainId', msgChainId)
+
         this.streamId = streamId
         this.streamPartition = streamPartition
         this.timestamp = timestamp

--- a/src/protocol/message_layer/MessageRef.js
+++ b/src/protocol/message_layer/MessageRef.js
@@ -1,5 +1,9 @@
+import { validateIsNotNegativeInteger } from '../../utils/validations'
+
 export default class MessageRef {
     constructor(timestamp, sequenceNumber) {
+        validateIsNotNegativeInteger('timestamp', timestamp)
+        validateIsNotNegativeInteger('sequenceNumber', sequenceNumber)
         this.timestamp = timestamp
         this.sequenceNumber = sequenceNumber
     }

--- a/src/protocol/message_layer/MessageRef.js
+++ b/src/protocol/message_layer/MessageRef.js
@@ -3,7 +3,7 @@ import { validateIsNotNegativeInteger } from '../../utils/validations'
 export default class MessageRef {
     constructor(timestamp, sequenceNumber) {
         validateIsNotNegativeInteger('timestamp', timestamp)
-        validateIsNotNegativeInteger('sequenceNumber', sequenceNumber)
+        validateIsNotNegativeInteger('sequenceNumber', sequenceNumber, true)
         this.timestamp = timestamp
         this.sequenceNumber = sequenceNumber
     }

--- a/src/protocol/message_layer/MessageRefStrict.js
+++ b/src/protocol/message_layer/MessageRefStrict.js
@@ -1,0 +1,12 @@
+import { validateIsNotNegativeInteger } from '../../utils/validations'
+import MessageRef from './MessageRef'
+
+/**
+ * Strict messageRef that requires sequenceNumber to be set
+ */
+export default class MessageRefStrict extends MessageRef {
+    constructor(timestamp, sequenceNumber) {
+        super(timestamp, sequenceNumber)
+        validateIsNotNegativeInteger('sequenceNumber', sequenceNumber)
+    }
+}

--- a/src/protocol/message_layer/StreamMessage.js
+++ b/src/protocol/message_layer/StreamMessage.js
@@ -1,4 +1,5 @@
 import InvalidJsonError from '../../errors/InvalidJsonError'
+import ValidationError from '../../errors/ValidationError'
 
 const BYE_KEY = '_bye'
 const LATEST_VERSION = 31
@@ -8,9 +9,12 @@ export default class StreamMessage {
         if (new.target === StreamMessage) {
             throw new TypeError('StreamMessage is abstract.')
         }
+
+        StreamMessage.validateContentType(contentType)
+        StreamMessage.validateEncryptionType(encryptionType)
+
         this.version = version
         this.streamId = streamId
-        StreamMessage.validateContentType(contentType)
         this.contentType = contentType
         this.encryptionType = encryptionType
 
@@ -142,7 +146,13 @@ export default class StreamMessage {
 
     static validateContentType(contentType) {
         if (!StreamMessage.VALID_CONTENTS.has(contentType)) {
-            throw new Error(`Unsupported content type: ${contentType}`)
+            throw new ValidationError(`Unsupported content type: ${contentType}`)
+        }
+    }
+
+    static validateEncryptionType(encryptionType) {
+        if (!StreamMessage.VALID_ENCRYPTIONS.has(encryptionType)) {
+            throw new ValidationError(`Unsupported encryption type: ${encryptionType}`)
         }
     }
 
@@ -204,3 +214,5 @@ StreamMessage.ENCRYPTION_TYPES = {
     AES: 2,
     NEW_KEY_AND_AES: 3,
 }
+
+StreamMessage.VALID_ENCRYPTIONS = new Set(Object.values(StreamMessage.ENCRYPTION_TYPES))

--- a/src/protocol/message_layer/StreamMessageV28.js
+++ b/src/protocol/message_layer/StreamMessageV28.js
@@ -84,13 +84,13 @@ export default class StreamMessageV28 extends StreamMessage {
             // null fields in order: msgId.publisherId, prevMsgRef.timestamp, prevMsgRef.sequenceNumber, signature
             return new StreamMessageV30(
                 [this.streamId, this.streamPartition, this.timestamp, 0, '', ''],
-                [null, null], this.contentType, this.getContent(), 0, null, this.parseContentOption,
+                null, this.contentType, this.getContent(), 0, null, this.parseContentOption,
             )
         } else if (version === 31) {
             // null fields in order: msgId.publisherId, prevMsgRef.timestamp, prevMsgRef.sequenceNumber, signature
             return new StreamMessageV31(
                 [this.streamId, this.streamPartition, this.timestamp, 0, '', ''],
-                [null, null], this.contentType, StreamMessage.ENCRYPTION_TYPES.NONE, this.getContent(), 0, null, this.parseContentOption,
+                null, this.contentType, StreamMessage.ENCRYPTION_TYPES.NONE, this.getContent(), 0, null, this.parseContentOption,
             )
         }
         throw new UnsupportedVersionError(version, 'Supported versions: [28, 29, 30, 31]')

--- a/src/protocol/message_layer/StreamMessageV28.js
+++ b/src/protocol/message_layer/StreamMessageV28.js
@@ -1,3 +1,4 @@
+import { validateIsNotNegativeInteger, validateIsInteger, validateIsNotEmptyString } from '../../utils/validations'
 import UnsupportedVersionError from '../../errors/UnsupportedVersionError'
 import StreamMessage from './StreamMessage'
 import StreamMessageV29 from './StreamMessageV29'
@@ -9,6 +10,14 @@ const VERSION = 28
 export default class StreamMessageV28 extends StreamMessage {
     constructor(streamId, streamPartition, timestamp, ttl, offset, previousOffset, contentType, content, parseContent = true) {
         super(VERSION, streamId, contentType, StreamMessage.ENCRYPTION_TYPES.NONE, content, parseContent)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition, true)
+        validateIsNotNegativeInteger('timestamp', timestamp, true)
+        validateIsNotNegativeInteger('ttl', ttl, true)
+        validateIsInteger('offset', offset, true)
+        validateIsInteger('previousOffset', previousOffset, true)
+
         this.ttl = ttl
         this.streamPartition = streamPartition
         this.timestamp = timestamp

--- a/src/protocol/message_layer/StreamMessageV29.js
+++ b/src/protocol/message_layer/StreamMessageV29.js
@@ -1,3 +1,9 @@
+import {
+    validateIsInteger,
+    validateIsString,
+    validateIsNotEmptyString,
+    validateIsNotNegativeInteger,
+} from '../../utils/validations'
 import UnsupportedVersionError from '../../errors/UnsupportedVersionError'
 import StreamMessage from './StreamMessage'
 import StreamMessageV28 from './StreamMessageV28'
@@ -12,6 +18,17 @@ export default class StreamMessageV29 extends StreamMessage {
         content, signatureType, publisherAddress, signature, parseContent = true,
     ) {
         super(VERSION, streamId, contentType, StreamMessage.ENCRYPTION_TYPES.NONE, content, parseContent)
+
+        validateIsNotEmptyString('streamId', streamId)
+        validateIsNotNegativeInteger('streamPartition', streamPartition, true)
+        validateIsNotNegativeInteger('timestamp', timestamp, true)
+        validateIsNotNegativeInteger('ttl', ttl, true)
+        validateIsInteger('offset', offset, true)
+        validateIsInteger('previousOffset', previousOffset, true)
+        validateIsInteger('signatureType', signatureType, true)
+        validateIsString('publisherAddress', publisherAddress, true)
+        validateIsString('signature', signature, true)
+
         this.ttl = ttl
         this.streamPartition = streamPartition
         this.timestamp = timestamp

--- a/src/protocol/message_layer/StreamMessageV29.js
+++ b/src/protocol/message_layer/StreamMessageV29.js
@@ -101,16 +101,15 @@ export default class StreamMessageV29 extends StreamMessage {
                 this.ttl, this.offset, this.previousOffset, this.contentType, this.getContent(), this.parseContentOption,
             )
         } else if (version === 30) {
-            // null fields in order: prevMsgRef.timestamp, prevMsgRef.sequenceNumber
             return new StreamMessageV30(
                 [this.streamId, this.streamPartition, this.timestamp, 0, this.publisherAddress || '', ''],
-                [null, null], this.contentType, this.getContent(), this.signatureType, this.signature, this.parseContentOption,
+                null, this.contentType, this.getContent(), this.signatureType, this.signature, this.parseContentOption,
             )
         } else if (version === 31) {
             // null fields in order: prevMsgRef.timestamp, prevMsgRef.sequenceNumber
             return new StreamMessageV31(
                 [this.streamId, this.streamPartition, this.timestamp, 0, this.publisherAddress || '', ''],
-                [null, null], this.contentType, StreamMessage.ENCRYPTION_TYPES.NONE, this.getContent(),
+                null, this.contentType, StreamMessage.ENCRYPTION_TYPES.NONE, this.getContent(),
                 this.signatureType, this.signature, this.parseContentOption,
             )
         }

--- a/src/protocol/message_layer/StreamMessageV30.js
+++ b/src/protocol/message_layer/StreamMessageV30.js
@@ -5,7 +5,7 @@ import StreamMessageV28 from './StreamMessageV28'
 import StreamMessageV29 from './StreamMessageV29'
 import StreamMessageV31 from './StreamMessageV31'
 import MessageID from './MessageID'
-import MessageRef from './MessageRef'
+import MessageRefStrict from './MessageRefStrict'
 
 const VERSION = 30
 
@@ -17,7 +17,7 @@ export default class StreamMessageV30 extends StreamMessage {
         validateIsString('signature', signature, true)
 
         this.messageId = new MessageID(...messageIdArgsArray)
-        this.prevMsgRef = prevMessageRefArgsArray ? new MessageRef(...prevMessageRefArgsArray) : null
+        this.prevMsgRef = prevMessageRefArgsArray ? new MessageRefStrict(...prevMessageRefArgsArray) : null
         this.signatureType = signatureType
         this.signature = signature
     }
@@ -47,7 +47,7 @@ export default class StreamMessageV30 extends StreamMessage {
     }
 
     getMessageRef() {
-        return new MessageRef(this.getTimestamp(), this.getSequenceNumber())
+        return new MessageRefStrict(this.getTimestamp(), this.getSequenceNumber())
     }
 
     toArray(parsedContent = false) {

--- a/src/protocol/message_layer/StreamMessageV30.js
+++ b/src/protocol/message_layer/StreamMessageV30.js
@@ -1,3 +1,4 @@
+import { validateIsInteger, validateIsString } from '../../utils/validations'
 import UnsupportedVersionError from '../../errors/UnsupportedVersionError'
 import StreamMessage from './StreamMessage'
 import StreamMessageV28 from './StreamMessageV28'
@@ -11,6 +12,10 @@ const VERSION = 30
 export default class StreamMessageV30 extends StreamMessage {
     constructor(messageIdArgsArray, prevMessageRefArgsArray, contentType, content, signatureType, signature, parseContent = true) {
         super(VERSION, undefined, contentType, StreamMessage.ENCRYPTION_TYPES.NONE, content, parseContent)
+
+        validateIsInteger('signatureType', signatureType)
+        validateIsString('signature', signature, true)
+
         this.messageId = new MessageID(...messageIdArgsArray)
         this.prevMsgRef = prevMessageRefArgsArray ? new MessageRef(...prevMessageRefArgsArray) : null
         this.signatureType = signatureType

--- a/src/protocol/message_layer/StreamMessageV31.js
+++ b/src/protocol/message_layer/StreamMessageV31.js
@@ -2,7 +2,7 @@ import { validateIsInteger, validateIsString } from '../../utils/validations'
 import UnsupportedVersionError from '../../errors/UnsupportedVersionError'
 import StreamMessage from './StreamMessage'
 import MessageID from './MessageID'
-import MessageRef from './MessageRef'
+import MessageRefStrict from './MessageRefStrict'
 import StreamMessageV28 from './StreamMessageV28'
 import StreamMessageV29 from './StreamMessageV29'
 import StreamMessageV30 from './StreamMessageV30'
@@ -17,7 +17,7 @@ export default class StreamMessageV31 extends StreamMessage {
         validateIsString('signature', signature, true)
 
         this.messageId = new MessageID(...messageIdArgsArray)
-        this.prevMsgRef = prevMessageRefArgsArray ? new MessageRef(...prevMessageRefArgsArray) : null
+        this.prevMsgRef = prevMessageRefArgsArray ? new MessageRefStrict(...prevMessageRefArgsArray) : null
         this.encryptionType = encryptionType
         this.signatureType = signatureType
         this.signature = signature
@@ -48,7 +48,7 @@ export default class StreamMessageV31 extends StreamMessage {
     }
 
     getMessageRef() {
-        return new MessageRef(this.getTimestamp(), this.getSequenceNumber())
+        return new MessageRefStrict(this.getTimestamp(), this.getSequenceNumber())
     }
 
     toArray(parsedContent = false) {

--- a/src/protocol/message_layer/StreamMessageV31.js
+++ b/src/protocol/message_layer/StreamMessageV31.js
@@ -1,3 +1,4 @@
+import { validateIsInteger, validateIsString } from '../../utils/validations'
 import UnsupportedVersionError from '../../errors/UnsupportedVersionError'
 import StreamMessage from './StreamMessage'
 import MessageID from './MessageID'
@@ -11,6 +12,10 @@ const VERSION = 31
 export default class StreamMessageV31 extends StreamMessage {
     constructor(messageIdArgsArray, prevMessageRefArgsArray, contentType, encryptionType, content, signatureType, signature, parseContent = true) {
         super(VERSION, undefined, contentType, encryptionType, content, parseContent)
+
+        validateIsInteger('signatureType', signatureType)
+        validateIsString('signature', signature, true)
+
         this.messageId = new MessageID(...messageIdArgsArray)
         this.prevMsgRef = prevMessageRefArgsArray ? new MessageRef(...prevMessageRefArgsArray) : null
         this.encryptionType = encryptionType

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -1,0 +1,50 @@
+import ValidationError from '../errors/ValidationError'
+
+export function validateIsNotNullOrUndefined(varName, varValue) {
+    if (varValue === undefined) {
+        throw new ValidationError(`Expected ${varName} to not be undefined.`)
+    }
+    if (varValue == null) {
+        throw new ValidationError(`Expected ${varName} to not be null.`)
+    }
+}
+
+export function validateIsString(varName, varValue, allowNull = false) {
+    if (allowNull && varValue == null) {
+        return
+    }
+    validateIsNotNullOrUndefined(varName, varValue)
+    if (typeof varValue !== 'string' && !(varValue instanceof String)) {
+        throw new ValidationError(`Expected ${varName} to be a string but was a ${typeof varValue} (${varValue}).`)
+    }
+}
+
+export function validateIsNotEmptyString(varName, varValue, allowNull = false) {
+    if (allowNull && varValue == null) {
+        return
+    }
+    validateIsString(varName, varValue)
+    if (varValue.length === 0) {
+        throw new ValidationError(`Expected ${varName} to not be an empty string.`)
+    }
+}
+
+export function validateIsInteger(varName, varValue, allowNull = false) {
+    if (allowNull && varValue == null) {
+        return
+    }
+    validateIsNotNullOrUndefined(varName, varValue)
+    if (!Number.isInteger(varValue)) {
+        throw new ValidationError(`Expected ${varName} to be an integer but was a ${typeof varValue} (${varValue}).`)
+    }
+}
+
+export function validateIsNotNegativeInteger(varName, varValue, allowNull = false) {
+    if (allowNull && varValue == null) {
+        return
+    }
+    validateIsInteger(varName, varValue)
+    if (varValue < 0) {
+        throw new ValidationError(`Expected ${varName} to not be negative (${varValue}).`)
+    }
+}

--- a/test/unit/protocol/message_layer/StreamMessageV28.test.js
+++ b/test/unit/protocol/message_layer/StreamMessageV28.test.js
@@ -60,7 +60,7 @@ describe('StreamMessageV28', () => {
         })
         it('correctly serializes messages to v30', () => {
             const arr = [30, ['TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, '', ''],
-                [null, null], StreamMessage.CONTENT_TYPES.MESSAGE, '{"valid": "json"}', 0, null]
+                null, StreamMessage.CONTENT_TYPES.MESSAGE, '{"valid": "json"}', 0, null]
 
             const serialized = new StreamMessageV28(
                 'TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0,
@@ -71,7 +71,7 @@ describe('StreamMessageV28', () => {
         })
         it('correctly serializes messages to v31', () => {
             const arr = [31, ['TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, '', ''],
-                [null, null], StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, '{"valid": "json"}', 0, null]
+                null, StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, '{"valid": "json"}', 0, null]
 
             const serialized = new StreamMessageV28(
                 'TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0,

--- a/test/unit/protocol/message_layer/StreamMessageV29.test.js
+++ b/test/unit/protocol/message_layer/StreamMessageV29.test.js
@@ -63,7 +63,7 @@ describe('StreamMessageV29', () => {
             })
             it('correctly serializes messages to v30', () => {
                 const arr = [30, ['TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, 'address', ''],
-                    [null, null], StreamMessage.CONTENT_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH_LEGACY, 'signature']
+                    null, StreamMessage.CONTENT_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH_LEGACY, 'signature']
 
                 const serialized = new StreamMessageV29(
                     'TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, 941516902, 941499898,
@@ -73,7 +73,7 @@ describe('StreamMessageV29', () => {
                 assert.deepEqual(serialized, JSON.stringify(arr))
             })
             it('correctly serializes messages to v31', () => {
-                const arr = [31, ['TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, 'address', ''], [null, null], StreamMessage.CONTENT_TYPES.MESSAGE,
+                const arr = [31, ['TsvTbqshTsuLg_HyUjxigA', 0, 1529549961116, 0, 'address', ''], null, StreamMessage.CONTENT_TYPES.MESSAGE,
                     StreamMessage.ENCRYPTION_TYPES.NONE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH_LEGACY, 'signature']
 
                 const serialized = new StreamMessageV29(

--- a/test/unit/protocol/message_layer/StreamMessageV30.test.js
+++ b/test/unit/protocol/message_layer/StreamMessageV30.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import StreamMessage from '../../../../src/protocol/message_layer/StreamMessage'
-import MessageRef from '../../../../src/protocol/message_layer/MessageRef'
+import MessageRefStrict from '../../../../src/protocol/message_layer/MessageRefStrict'
 import StreamMessageV30 from '../../../../src/protocol/message_layer/StreamMessageV30'
 
 describe('StreamMessageV30', () => {
@@ -16,7 +16,7 @@ describe('StreamMessageV30', () => {
             assert.equal(result.getTimestamp(), 1529549961116)
             assert.equal(result.getSequenceNumber(), 0)
             assert.equal(result.getPublisherId(), 'publisherId')
-            assert.deepStrictEqual(result.getMessageRef(), new MessageRef(1529549961116, 0))
+            assert.deepStrictEqual(result.getMessageRef(), new MessageRefStrict(1529549961116, 0))
             assert.equal(result.getMsgChainId(), 'msg-chain-id')
             assert.equal(result.prevMsgRef.timestamp, 1529549961000)
             assert.equal(result.prevMsgRef.sequenceNumber, 0)

--- a/test/unit/protocol/message_layer/StreamMessageV30.test.js
+++ b/test/unit/protocol/message_layer/StreamMessageV30.test.js
@@ -128,7 +128,7 @@ describe('StreamMessageV30', () => {
                 foo: 'bar',
             }
             const msg = new StreamMessageV30(
-                ['streamId', 0, Date.now(), 0, 'publisherId', 1], [1529549961000, 0], StreamMessage.CONTENT_TYPES.MESSAGE, content,
+                ['streamId', 0, Date.now(), 0, 'publisherId', '1'], [1529549961000, 0], StreamMessage.CONTENT_TYPES.MESSAGE, content,
                 StreamMessage.SIGNATURE_TYPES.ETH, 'signature',
             )
             assert.deepEqual(msg.getParsedContent(), content)
@@ -138,7 +138,7 @@ describe('StreamMessageV30', () => {
                 foo: 'bar',
             }
             const msg = new StreamMessageV30(
-                ['streamId', 0, Date.now(), 0, 'publisherId', 1], [1529549961000, 0], StreamMessage.CONTENT_TYPES.MESSAGE, JSON.stringify(content),
+                ['streamId', 0, Date.now(), 0, 'publisherId', '1'], [1529549961000, 0], StreamMessage.CONTENT_TYPES.MESSAGE, JSON.stringify(content),
                 StreamMessage.SIGNATURE_TYPES.ETH, 'signature',
             )
             assert.deepEqual(msg.getParsedContent(), content)

--- a/test/unit/protocol/message_layer/StreamMessageV31.test.js
+++ b/test/unit/protocol/message_layer/StreamMessageV31.test.js
@@ -125,7 +125,7 @@ describe('StreamMessageV31', () => {
                 foo: 'bar',
             }
             const msg = new StreamMessageV31(
-                ['streamId', 0, Date.now(), 0, 'publisherId', 1], [1529549961000, 0],
+                ['streamId', 0, Date.now(), 0, 'publisherId', '1'], [1529549961000, 0],
                 StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, content,
                 StreamMessage.SIGNATURE_TYPES.ETH, 'signature',
             )
@@ -136,7 +136,7 @@ describe('StreamMessageV31', () => {
                 foo: 'bar',
             }
             const msg = new StreamMessageV31(
-                ['streamId', 0, Date.now(), 0, 'publisherId', 1], [1529549961000, 0],
+                ['streamId', 0, Date.now(), 0, 'publisherId', '1'], [1529549961000, 0],
                 StreamMessage.CONTENT_TYPES.MESSAGE, StreamMessage.ENCRYPTION_TYPES.NONE, JSON.stringify(content),
                 StreamMessage.SIGNATURE_TYPES.ETH, 'signature',
             )
@@ -183,7 +183,7 @@ describe('StreamMessageV31', () => {
                 },
                 StreamMessage.SIGNATURE_TYPES.NONE, null,
             ), (err) => {
-                assert.equal(err.message, 'streamId must be defined!')
+                assert.equal(err.message, 'Expected streamId to not be undefined.')
                 return true
             })
         })

--- a/test/unit/protocol/message_layer/StreamMessageV31.test.js
+++ b/test/unit/protocol/message_layer/StreamMessageV31.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import StreamMessage from '../../../../src/protocol/message_layer/StreamMessage'
-import MessageRef from '../../../../src/protocol/message_layer/MessageRef'
+import MessageRefStrict from '../../../../src/protocol/message_layer/MessageRefStrict'
 import StreamMessageV31 from '../../../../src/protocol/message_layer/StreamMessageV31'
 import StreamMessageFactory from '../../../../src/protocol/message_layer/StreamMessageFactory'
 
@@ -18,7 +18,7 @@ describe('StreamMessageV31', () => {
             assert.equal(result.getTimestamp(), 1529549961116)
             assert.equal(result.getSequenceNumber(), 0)
             assert.equal(result.getPublisherId(), 'publisherId')
-            assert.deepStrictEqual(result.getMessageRef(), new MessageRef(1529549961116, 0))
+            assert.deepStrictEqual(result.getMessageRef(), new MessageRefStrict(1529549961116, 0))
             assert.equal(result.getMsgChainId(), 'msg-chain-id')
             assert.equal(result.prevMsgRef.timestamp, 1529549961000)
             assert.equal(result.prevMsgRef.sequenceNumber, 0)

--- a/test/unit/utils/validations.test.js
+++ b/test/unit/utils/validations.test.js
@@ -1,0 +1,269 @@
+import {
+    validateIsNotNullOrUndefined,
+    validateIsString,
+    validateIsNotEmptyString,
+    validateIsInteger,
+    validateIsNotNegativeInteger,
+} from '../../../src/utils/validations'
+import ValidationError from '../../../src/errors/ValidationError'
+
+describe('validations', () => {
+    describe('validateIsNotNullOrUndefined', () => {
+        it('throws ValidationError on undefined', () => {
+            expect(() => {
+                validateIsNotNullOrUndefined('varName', undefined)
+            }).toThrow(new ValidationError('Expected varName to not be undefined.'))
+        })
+        it('throws ValidationError on null', () => {
+            expect(() => {
+                validateIsNotNullOrUndefined('varName', null)
+            }).toThrow(new ValidationError('Expected varName to not be null.'))
+        })
+    })
+
+    describe('validateIsString', () => {
+        describe('when allowNull = false (default)', () => {
+            it('throws ValidationError on undefined', () => {
+                expect(() => {
+                    validateIsString('varName', undefined)
+                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
+            })
+            it('throws ValidationError on null', () => {
+                expect(() => {
+                    validateIsString('varName', null)
+                }).toThrow(new ValidationError('Expected varName to not be null.'))
+            })
+        })
+        describe('when allowNull = true', () => {
+            it('does not throw on undefined', () => {
+                expect(() => {
+                    validateIsString('varName', undefined, true)
+                }).not.toThrow()
+            })
+            it('does not throw on null', () => {
+                expect(() => {
+                    validateIsString('varName', null, true)
+                }).not.toThrow()
+            })
+        })
+        it('throws ValidationError on number', () => {
+            expect(() => {
+                validateIsString('varName', 10)
+            }).toThrow(new ValidationError('Expected varName to be a string but was a number (10).'))
+        })
+        it('throws ValidationError on object', () => {
+            expect(() => {
+                validateIsString('varName', {
+                    hello: 'world',
+                })
+            }).toThrow(new ValidationError('Expected varName to be a string but was a object ([object Object]).'))
+        })
+        it('does not throw on empty string', () => {
+            expect(() => {
+                validateIsString('varName', '')
+            }).not.toThrow()
+        })
+        it('does not throw on non-empty string', () => {
+            expect(() => {
+                validateIsString('varName', 'hello, world')
+            }).not.toThrow()
+        })
+    })
+
+    describe('validateIsNotEmptyString', () => {
+        describe('when allowNull = false (default)', () => {
+            it('throws ValidationError on undefined', () => {
+                expect(() => {
+                    validateIsNotEmptyString('varName', undefined)
+                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
+            })
+            it('throws ValidationError on null', () => {
+                expect(() => {
+                    validateIsNotEmptyString('varName', null)
+                }).toThrow(new ValidationError('Expected varName to not be null.'))
+            })
+        })
+        describe('when allowNull = true', () => {
+            it('does not throw on undefined', () => {
+                expect(() => {
+                    validateIsNotEmptyString('varName', undefined, true)
+                }).not.toThrow()
+            })
+            it('does not throw on null', () => {
+                expect(() => {
+                    validateIsNotEmptyString('varName', null, true)
+                }).not.toThrow()
+            })
+        })
+        it('throws ValidationError on number', () => {
+            expect(() => {
+                validateIsNotEmptyString('varName', 10)
+            }).toThrow(new ValidationError('Expected varName to be a string but was a number (10).'))
+        })
+        it('throws ValidationError on object', () => {
+            expect(() => {
+                validateIsNotEmptyString('varName', {
+                    hello: 'world',
+                })
+            }).toThrow(new ValidationError('Expected varName to be a string but was a object ([object Object]).'))
+        })
+        it('throws on empty string', () => {
+            expect(() => {
+                validateIsNotEmptyString('varName', '')
+            }).toThrow(new ValidationError('Expected varName to not be an empty string.'))
+        })
+        it('does not throw on non-empty string', () => {
+            expect(() => {
+                validateIsNotEmptyString('varName', 'hello, world')
+            }).not.toThrow()
+        })
+    })
+
+    describe('validateIsInteger', () => {
+        describe('when allowNull = false (default)', () => {
+            it('throws ValidationError on undefined', () => {
+                expect(() => {
+                    validateIsInteger('varName', undefined)
+                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
+            })
+            it('throws ValidationError on null', () => {
+                expect(() => {
+                    validateIsInteger('varName', null)
+                }).toThrow(new ValidationError('Expected varName to not be null.'))
+            })
+        })
+        describe('when allowNull = true', () => {
+            it('does not throw on undefined', () => {
+                expect(() => {
+                    validateIsInteger('varName', undefined, true)
+                }).not.toThrow()
+            })
+            it('does not throw on null', () => {
+                expect(() => {
+                    validateIsInteger('varName', null, true)
+                }).not.toThrow()
+            })
+        })
+        it('throws ValidationError on string', () => {
+            expect(() => {
+                validateIsInteger('varName', 'string')
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a string (string).'))
+        })
+        it('throws ValidationError on object', () => {
+            expect(() => {
+                validateIsInteger('varName', {
+                    hello: 'world',
+                })
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a object ([object Object]).'))
+        })
+        it('throws ValidationError on NaN', () => {
+            expect(() => {
+                validateIsInteger('varName', NaN)
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (NaN).'))
+        })
+        it('throws ValidationError on infinity', () => {
+            expect(() => {
+                validateIsInteger('varName', Number.POSITIVE_INFINITY)
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (Infinity).'))
+        })
+        it('throws ValidationError on number that is not representable as an integer', () => {
+            expect(() => {
+                validateIsInteger('varName', 6.66)
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (6.66).'))
+        })
+        it('does not throw on negative integer', () => {
+            expect(() => {
+                validateIsInteger('varName', -10)
+            }).not.toThrow()
+        })
+        it('does not throw on zero integer', () => {
+            expect(() => {
+                validateIsInteger('varName', 0)
+            }).not.toThrow()
+        })
+        it('does not throw on positive integer', () => {
+            expect(() => {
+                validateIsInteger('varName', 10)
+            }).not.toThrow()
+        })
+        it('does not throw on number that is representable as an integer', () => {
+            expect(() => {
+                validateIsInteger('varName', 10.00)
+            }).not.toThrow()
+        })
+    })
+
+    describe('validateIsNotNegativeInteger', () => {
+        describe('when allowNull = false (default)', () => {
+            it('throws ValidationError on undefined', () => {
+                expect(() => {
+                    validateIsNotNegativeInteger('varName', undefined)
+                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
+            })
+            it('throws ValidationError on null', () => {
+                expect(() => {
+                    validateIsNotNegativeInteger('varName', null)
+                }).toThrow(new ValidationError('Expected varName to not be null.'))
+            })
+        })
+        describe('when allowNull = true', () => {
+            it('does not throw on undefined', () => {
+                expect(() => {
+                    validateIsNotNegativeInteger('varName', undefined, true)
+                }).not.toThrow()
+            })
+            it('does not throw on null', () => {
+                expect(() => {
+                    validateIsNotNegativeInteger('varName', null, true)
+                }).not.toThrow()
+            })
+        })
+        it('throws ValidationError on string', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', 'string')
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a string (string).'))
+        })
+        it('throws ValidationError on object', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', {
+                    hello: 'world',
+                })
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a object ([object Object]).'))
+        })
+        it('throws ValidationError on NaN', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', NaN)
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (NaN).'))
+        })
+        it('throws ValidationError on infinity', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', Number.POSITIVE_INFINITY)
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (Infinity).'))
+        })
+        it('throws ValidationError on number that is not representable as an integer', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', 6.66)
+            }).toThrow(new ValidationError('Expected varName to be an integer but was a number (6.66).'))
+        })
+        it('throws on negative integer', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', -10)
+            }).toThrow(new ValidationError('Expected varName to not be negative (-10).'))
+        })
+        it('does not throw on zero integer', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', 0)
+            }).not.toThrow()
+        })
+        it('does not throw on positive integer', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', 10)
+            }).not.toThrow()
+        })
+        it('does not throw on number that is representable as an integer', () => {
+            expect(() => {
+                validateIsNotNegativeInteger('varName', 10.00)
+            }).not.toThrow()
+        })
+    })
+})


### PR DESCRIPTION
Add validation to the constructors of message classes. Two benefits. Firstly, allows us to catch errors caused by missing fields earlier in the execution of a request. Secondly, allows us to get rid of some basic validation checks in client and broker as we can assume that presence (and types) of fields have been checked in constructor. 

### Changeset
- 1st commit: validation functions and unit tests for them.
- 2nd commit: adding (and replacing existing) validation into messages classes. I'm not entirely sure about the optionality of some of the fields, especially those of the older versions V28, V29, and V0. Thus I opted to assume optionality in cases in which I was unsure. 
- 3rd commit: this is a change to the behavior of `toOtherVersion` which can potentially break something if we are depending on this behavior somewhere. It is quite arbitrary, so I'm wondering if this is the case really.
4th commit: Fix a few tests, e.g., some were using integers as msgChainId. Some fixes are related to the behavior change introduced in the 3rd commit.

### Version upgrade
This PR has a high chance of breaking something in broker or client. Thus we should treat it as a _major_ version upgrade and take necessary precautions before migrating broker or client to use this changeset.