### PR TITLE
Prevent out-of-sequence prevMsgRef

### DIFF
--- a/src/protocol/message_layer/StreamMessage.js
+++ b/src/protocol/message_layer/StreamMessage.js
@@ -248,13 +248,16 @@ export default class StreamMessage {
         if (!prevMsgRef) {
             return
         }
+
         const comparison = messageId.toMessageRef().compareTo(prevMsgRef)
+
+        // cannot have same timestamp + sequence
         if (comparison === 0) {
-            // cannot have same timestamp + sequence
             throw new ValidationError(`prevMessageRef cannot be identical to current. Current: ${messageId.toArray()} Previous: ${prevMsgRef.toArray()}`)
         }
+
+        // previous cannot be newer
         if (comparison < 0) {
-            // previous cannot be newer
             throw new ValidationError(`prevMessageRef must come before current. Current: ${messageId.toArray()} Previous: ${prevMsgRef.toArray()}`)
         }
     }

--- a/src/protocol/message_layer/StreamMessage.js
+++ b/src/protocol/message_layer/StreamMessage.js
@@ -253,12 +253,12 @@ export default class StreamMessage {
 
         // cannot have same timestamp + sequence
         if (comparison === 0) {
-            throw new ValidationError(`prevMessageRef cannot be identical to current. Current: ${messageId.toArray()} Previous: ${prevMsgRef.toArray()}`)
+            throw new ValidationError(`prevMessageRef cannot be identical to current. Current: ${messageId.toMessageRef().toArray()} Previous: ${prevMsgRef.toArray()}`)
         }
 
         // previous cannot be newer
         if (comparison < 0) {
-            throw new ValidationError(`prevMessageRef must come before current. Current: ${messageId.toArray()} Previous: ${prevMsgRef.toArray()}`)
+            throw new ValidationError(`prevMessageRef must come before current. Current: ${messageId.toMessageRef().toArray()} Previous: ${prevMsgRef.toArray()}`)
         }
     }
 

--- a/test/unit/protocol/message_layer/StreamMessage.test.js
+++ b/test/unit/protocol/message_layer/StreamMessage.test.js
@@ -141,6 +141,33 @@ describe('StreamMessage', () => {
                     prevMsgRef: new MessageRef(ts - 1, 0)
                 }), ValidationError)
             })
+
+            it('works with valid seq', () => {
+                const ts = Date.now()
+                msg({
+                    timestamp: ts,
+                    sequenceNumber: 0,
+                    prevMsgRef: new MessageRef(ts, 1)
+                })
+            })
+
+            it('works with valid ts', () => {
+                const ts = Date.now()
+                msg({
+                    timestamp: ts,
+                    sequenceNumber: 0,
+                    prevMsgRef: new MessageRef(ts + 1, 0)
+                })
+            })
+
+            it('works with no prevMsgRef', () => {
+                const ts = Date.now()
+                msg({
+                    timestamp: ts,
+                    sequenceNumber: 0,
+                    prevMsgRef: null
+                })
+            })
         })
     })
 

--- a/test/unit/protocol/message_layer/StreamMessage.test.js
+++ b/test/unit/protocol/message_layer/StreamMessage.test.js
@@ -114,6 +114,34 @@ describe('StreamMessage', () => {
                 newGroupKey: 'foo', // invalid
             }), ValidationError)
         })
+
+        describe('prevMsgRef validation', () => {
+            it('Throws with an invalid ts', () => {
+                const ts = Date.now()
+                assert.throws(() => msg({
+                    timestamp: ts,
+                    prevMsgRef: new MessageRef(ts - 1, 0)
+                }), ValidationError)
+            })
+
+            it('Throws with an invalid sequence', () => {
+                const ts = Date.now()
+                assert.throws(() => msg({
+                    timestamp: ts,
+                    sequenceNumber: 1,
+                    prevMsgRef: new MessageRef(ts, 0)
+                }), ValidationError)
+            })
+
+            it('Throws with an invalid ts + seq', () => {
+                const ts = Date.now()
+                assert.throws(() => msg({
+                    timestamp: ts,
+                    sequenceNumber: 1,
+                    prevMsgRef: new MessageRef(ts - 1, 0)
+                }), ValidationError)
+            })
+        })
     })
 
     describe('serialization', () => {


### PR DESCRIPTION
Prevents invalid sequences at message creation time.
Related to https://github.com/streamr-dev/streamr-client-javascript/pull/166