### PR TITLE
new RTC-related messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.1.0-0",
+  "version": "6.1.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.0.3",
+  "version": "6.1.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.1.1-0",
+  "version": "6.1.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.0.3",
+  "version": "6.1.0-0",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.1.1-0",
+  "version": "6.1.2-0",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.1.0-0",
+  "version": "6.1.1-0",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -5,11 +5,15 @@ import './protocol/control_layer/broadcast_message/BroadcastMessageSerializerV2'
 import ErrorResponse from './protocol/control_layer/error_response/ErrorResponse'
 import './protocol/control_layer/error_response/ErrorResponseSerializerV1'
 import './protocol/control_layer/error_response/ErrorResponseSerializerV2'
+import ErrorMessage from './protocol/tracker_layer/error_message/ErrorMessage'
+import './protocol/tracker_layer/error_message/ErrorMessageSerializerV1'
 import InstructionMessage from './protocol/tracker_layer/instruction_message/InstructionMessage'
 import './protocol/tracker_layer/instruction_message/InstructionMessageSerializerV1'
 import PublishRequest from './protocol/control_layer/publish_request/PublishRequest'
 import './protocol/control_layer/publish_request/PublishRequestSerializerV1'
 import './protocol/control_layer/publish_request/PublishRequestSerializerV2'
+import RelayMessage from './protocol/tracker_layer/relay_message/RelayMessage'
+import './protocol/tracker_layer/relay_message/RelayMessageSerializerV1'
 import ResendFromRequest from './protocol/control_layer/resend_request/ResendFromRequest'
 import './protocol/control_layer/resend_request/ResendFromRequestSerializerV1'
 import './protocol/control_layer/resend_request/ResendFromRequestSerializerV2'
@@ -110,6 +114,8 @@ export const MessageLayer = {
 
 export const TrackerLayer = {
     InstructionMessage,
+    ErrorMessage,
+    RelayMessage,
     StatusMessage,
     StorageNodesRequest,
     StorageNodesResponse,

--- a/src/protocol/tracker_layer/TrackerMessage.js
+++ b/src/protocol/tracker_layer/TrackerMessage.js
@@ -87,5 +87,7 @@ TrackerMessage.TYPES = {
     StatusMessage: 1,
     InstructionMessage: 2,
     StorageNodesRequest: 3,
-    StorageNodesResponse: 4
+    StorageNodesResponse: 4,
+    RelayMessage: 5,
+    ErrorMessage: 6
 }

--- a/src/protocol/tracker_layer/error_message/ErrorMessage.js
+++ b/src/protocol/tracker_layer/error_message/ErrorMessage.js
@@ -1,0 +1,23 @@
+import {
+    validateIsOneOf,
+    validateIsNotEmptyString,
+} from '../../../utils/validations'
+import TrackerMessage from '../TrackerMessage'
+
+const ERROR_CODES = Object.freeze({
+    RTC_UNKNOWN_PEER: 'RTC_UNKNOWN_PEER'
+})
+
+export default class ErrorMessage extends TrackerMessage {
+    constructor({ version = TrackerMessage.LATEST_VERSION, requestId, errorCode, targetNode }) {
+        super(version, TrackerMessage.TYPES.ErrorMessage, requestId)
+
+        validateIsOneOf('errorCode', errorCode, Object.values(ERROR_CODES))
+        validateIsNotEmptyString('targetNode', targetNode)
+
+        this.errorCode = errorCode
+        this.targetNode = targetNode
+    }
+}
+
+ErrorMessage.ERROR_CODES = ERROR_CODES

--- a/src/protocol/tracker_layer/error_message/ErrorMessageSerializerV1.js
+++ b/src/protocol/tracker_layer/error_message/ErrorMessageSerializerV1.js
@@ -1,0 +1,33 @@
+import TrackerMessage from '../TrackerMessage'
+
+import ErrorMessage from './ErrorMessage'
+
+const VERSION = 1
+
+export default class ErrorMessageSerializerV1 {
+    static toArray(errorMessage) {
+        return [
+            VERSION,
+            TrackerMessage.TYPES.ErrorMessage,
+            errorMessage.requestId,
+            errorMessage.errorCode,
+            errorMessage.targetNode,
+        ]
+    }
+
+    static fromArray(arr) {
+        const [
+            version,
+            type, // eslint-disable-line no-unused-vars
+            requestId,
+            errorCode,
+            targetNode
+        ] = arr
+
+        return new ErrorMessage({
+            version, requestId, errorCode, targetNode
+        })
+    }
+}
+
+TrackerMessage.registerSerializer(VERSION, TrackerMessage.TYPES.ErrorMessage, ErrorMessageSerializerV1)

--- a/src/protocol/tracker_layer/instruction_message/InstructionMessage.js
+++ b/src/protocol/tracker_layer/instruction_message/InstructionMessage.js
@@ -7,18 +7,18 @@ import TrackerMessage from '../TrackerMessage'
 
 export default class InstructionMessage extends TrackerMessage {
     constructor({
-        version = TrackerMessage.LATEST_VERSION, requestId, streamId, streamPartition, nodeAddresses, counter
+        version = TrackerMessage.LATEST_VERSION, requestId, streamId, streamPartition, nodeIds, counter
     }) {
         super(version, TrackerMessage.TYPES.InstructionMessage, requestId)
 
         validateIsNotEmptyString('streamId', streamId)
         validateIsNotNegativeInteger('streamPartition', streamPartition)
-        validateIsArray('nodeAddresses', nodeAddresses)
+        validateIsArray('nodeIds', nodeIds)
         validateIsNotNegativeInteger('counter', counter)
 
         this.streamId = streamId
         this.streamPartition = streamPartition
-        this.nodeAddresses = nodeAddresses
+        this.nodeIds = nodeIds
         this.counter = counter
     }
 }

--- a/src/protocol/tracker_layer/instruction_message/InstructionMessageSerializerV1.js
+++ b/src/protocol/tracker_layer/instruction_message/InstructionMessageSerializerV1.js
@@ -12,7 +12,7 @@ export default class InstructionMessageSerializerV1 {
             instructionMessage.requestId,
             instructionMessage.streamId,
             instructionMessage.streamPartition,
-            instructionMessage.nodeAddresses,
+            instructionMessage.nodeIds,
             instructionMessage.counter
         ]
     }
@@ -24,12 +24,12 @@ export default class InstructionMessageSerializerV1 {
             requestId,
             streamId,
             streamPartition,
-            nodeAddresses,
+            nodeIds,
             counter
         ] = arr
 
         return new InstructionMessage({
-            version, requestId, streamId, streamPartition, nodeAddresses, counter
+            version, requestId, streamId, streamPartition, nodeIds, counter
         })
     }
 }

--- a/src/protocol/tracker_layer/relay_message/RelayMessage.js
+++ b/src/protocol/tracker_layer/relay_message/RelayMessage.js
@@ -1,0 +1,28 @@
+import {
+    validateIsNotEmptyString,
+    validateIsNotNullOrUndefined,
+} from '../../../utils/validations'
+import TrackerMessage from '../TrackerMessage'
+
+export default class RelayMessage extends TrackerMessage {
+    constructor({
+        version = TrackerMessage.LATEST_VERSION,
+        requestId,
+        originator,
+        targetNode,
+        subType,
+        data
+    }) {
+        super(version, TrackerMessage.TYPES.RelayMessage, requestId)
+
+        validateIsNotNullOrUndefined('originator', originator)
+        validateIsNotEmptyString('targetNode', targetNode)
+        validateIsNotEmptyString('subType', subType)
+        validateIsNotNullOrUndefined('data', data)
+
+        this.originator = originator
+        this.targetNode = targetNode
+        this.subType = subType
+        this.data = data
+    }
+}

--- a/src/protocol/tracker_layer/relay_message/RelayMessageSerializerV1.js
+++ b/src/protocol/tracker_layer/relay_message/RelayMessageSerializerV1.js
@@ -1,0 +1,37 @@
+import TrackerMessage from '../TrackerMessage'
+
+import RelayMessage from './RelayMessage'
+
+const VERSION = 1
+
+export default class RelayMessageSerializerV1 {
+    static toArray(relayMessage) {
+        return [
+            VERSION,
+            TrackerMessage.TYPES.RelayMessage,
+            relayMessage.requestId,
+            relayMessage.originator,
+            relayMessage.targetNode,
+            relayMessage.subType,
+            relayMessage.data
+        ]
+    }
+
+    static fromArray(arr) {
+        const [
+            version,
+            type, // eslint-disable-line no-unused-vars
+            requestId,
+            originator,
+            targetNode,
+            subType,
+            data
+        ] = arr
+
+        return new RelayMessage({
+            version, requestId, originator, targetNode, subType, data
+        })
+    }
+}
+
+TrackerMessage.registerSerializer(VERSION, TrackerMessage.TYPES.RelayMessage, RelayMessageSerializerV1)

--- a/src/protocol/tracker_layer/storage_nodes_response/StorageNodesResponse.js
+++ b/src/protocol/tracker_layer/storage_nodes_response/StorageNodesResponse.js
@@ -7,16 +7,16 @@ import TrackerMessage from '../TrackerMessage'
 
 export default class StorageNodesResponse extends TrackerMessage {
     constructor({
-        version = TrackerMessage.LATEST_VERSION, requestId, streamId, streamPartition, nodeAddresses
+        version = TrackerMessage.LATEST_VERSION, requestId, streamId, streamPartition, nodeIds
     }) {
         super(version, TrackerMessage.TYPES.StorageNodesResponse, requestId)
 
         validateIsNotEmptyString('streamId', streamId)
         validateIsNotNegativeInteger('streamPartition', streamPartition)
-        validateIsArray('nodeAddresses', nodeAddresses)
+        validateIsArray('nodeIds', nodeIds)
 
         this.streamId = streamId
         this.streamPartition = streamPartition
-        this.nodeAddresses = nodeAddresses
+        this.nodeIds = nodeIds
     }
 }

--- a/src/protocol/tracker_layer/storage_nodes_response/StorageNodesResponseSerializerV1.js
+++ b/src/protocol/tracker_layer/storage_nodes_response/StorageNodesResponseSerializerV1.js
@@ -12,7 +12,7 @@ export default class StorageNodesResponseSerializerV1 {
             storageNodesResponse.requestId,
             storageNodesResponse.streamId,
             storageNodesResponse.streamPartition,
-            storageNodesResponse.nodeAddresses
+            storageNodesResponse.nodeIds
         ]
     }
 
@@ -23,11 +23,11 @@ export default class StorageNodesResponseSerializerV1 {
             requestId,
             streamId,
             streamPartition,
-            nodeAddresses
+            nodeIds
         ] = arr
 
         return new StorageNodesResponse({
-            version, requestId, streamId, streamPartition, nodeAddresses
+            version, requestId, streamId, streamPartition, nodeIds
         })
     }
 }

--- a/src/utils/validations.js
+++ b/src/utils/validations.js
@@ -68,3 +68,13 @@ export function validateIsType(varName, varValue, typeName, typeClass, allowNull
     }
 }
 
+export function validateIsOneOf(varName, varValue, validValues, allowNull = false) {
+    if (allowNull && varValue == null) {
+        return
+    }
+    validateIsNotNullOrUndefined(varName, varValue)
+    if (!validValues.includes(varValue)) {
+        throw new ValidationError(`Expected ${varName} to be one of ${JSON.stringify(validValues)} but was (${varValue}).`)
+    }
+}
+

--- a/test/integration/TrackerRegistry.test.js
+++ b/test/integration/TrackerRegistry.test.js
@@ -11,15 +11,15 @@ describe('TrackerRegistry', () => {
 
         expect(trackerRegistry.getAllTrackers()).toStrictEqual([
             {
-                http: 'http://10.200.10.1:11111',
+                http: 'http://10.200.10.1:30301',
                 ws: 'ws://10.200.10.1:30301'
             },
             {
-                http: 'http://10.200.10.1:11112',
+                http: 'http://10.200.10.1:30302',
                 ws: 'ws://10.200.10.1:30302'
             },
             {
-                http: 'http://10.200.10.1:11113',
+                http: 'http://10.200.10.1:30303',
                 ws: 'ws://10.200.10.1:30303'
             }
         ])
@@ -65,15 +65,15 @@ describe('TrackerRegistry', () => {
 
         // 1->1, 2->2, 3->3 coincidence
         expect(trackerRegistry.getTracker('stream-1::0')).toEqual({
-            http: 'http://10.200.10.1:11111',
+            http: 'http://10.200.10.1:30301',
             ws: 'ws://10.200.10.1:30301'
         })
         expect(trackerRegistry.getTracker('stream-2::0')).toEqual({
-            http: 'http://10.200.10.1:11112',
+            http: 'http://10.200.10.1:30302',
             ws: 'ws://10.200.10.1:30302'
         })
         expect(trackerRegistry.getTracker('stream-3::0')).toEqual({
-            http: 'http://10.200.10.1:11113',
+            http: 'http://10.200.10.1:30303',
             ws: 'ws://10.200.10.1:30303'
         })
     })

--- a/test/unit/protocol/tracker_layer/ErrorMessage.test.js
+++ b/test/unit/protocol/tracker_layer/ErrorMessage.test.js
@@ -1,0 +1,50 @@
+import assert from 'assert'
+
+import ValidationError from '../../../../src/errors/ValidationError'
+import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
+import ErrorMessage from '../../../../src/protocol/tracker_layer/error_message/ErrorMessage'
+
+describe('ErrorMessage', () => {
+    describe('constructor', () => {
+        it('throws on null targetNode', () => {
+            assert.throws(() => new ErrorMessage({
+                requestId: 'requestId',
+                errorCode: ErrorMessage.ERROR_CODES.RTC_UNKNOWN_PEER,
+                targetNode: null
+            }), ValidationError)
+        })
+        it('throws on null errorCode', () => {
+            assert.throws(() => new ErrorMessage({
+                requestId: 'requestId',
+                errorCode: null,
+                targetNode: 'targetNode'
+            }), ValidationError)
+        })
+        it('throws on invalid errorCode', () => {
+            assert.throws(() => new ErrorMessage({
+                requestId: 'requestId',
+                errorCode: 'INVALID-CODE',
+                targetNode: 'targetNode'
+            }), ValidationError)
+        })
+        it('throws on null requestId', () => {
+            assert.throws(() => new ErrorMessage({
+                requestId: null,
+                errorCode: ErrorMessage.ERROR_CODES.RTC_UNKNOWN_PEER,
+                targetNode: 'targetNode'
+            }), ValidationError)
+        })
+        it('should create the latest version', () => {
+            const msg = new ErrorMessage({
+                requestId: 'requestId',
+                errorCode: ErrorMessage.ERROR_CODES.RTC_UNKNOWN_PEER,
+                targetNode: 'targetNode'
+            })
+            assert(msg instanceof ErrorMessage)
+            assert.strictEqual(msg.version, TrackerMessage.LATEST_VERSION)
+            assert.strictEqual(msg.requestId, 'requestId')
+            assert.strictEqual(msg.errorCode, ErrorMessage.ERROR_CODES.RTC_UNKNOWN_PEER)
+            assert.strictEqual(msg.targetNode, 'targetNode')
+        })
+    })
+})

--- a/test/unit/protocol/tracker_layer/ErrorMessageSerializerV1.test.js
+++ b/test/unit/protocol/tracker_layer/ErrorMessageSerializerV1.test.js
@@ -1,0 +1,36 @@
+import assert from 'assert'
+
+import { TrackerLayer } from '../../../../src'
+import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
+
+const { ErrorMessage } = TrackerLayer
+
+const VERSION = 1
+
+// Message definitions
+const message = new ErrorMessage({
+    version: VERSION,
+    requestId: 'requestId',
+    errorCode: ErrorMessage.ERROR_CODES.RTC_UNKNOWN_PEER,
+    targetNode: 'targetNode'
+})
+const serializedMessage = JSON.stringify([
+    VERSION,
+    TrackerMessage.TYPES.ErrorMessage,
+    'requestId',
+    ErrorMessage.ERROR_CODES.RTC_UNKNOWN_PEER,
+    'targetNode'
+])
+
+describe('ErrorMessageSerializerV1', () => {
+    describe('deserialize', () => {
+        it('correctly parses messages', () => {
+            assert.deepStrictEqual(TrackerMessage.deserialize(serializedMessage), message)
+        })
+    })
+    describe('serialize', () => {
+        it('correctly serializes messages', () => {
+            assert.deepStrictEqual(message.serialize(VERSION), serializedMessage)
+        })
+    })
+})

--- a/test/unit/protocol/tracker_layer/InstructionMessage.test.js
+++ b/test/unit/protocol/tracker_layer/InstructionMessage.test.js
@@ -11,16 +11,16 @@ describe('InstructionMessage', () => {
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: [],
+                nodeIds: [],
                 counter: null
             }), ValidationError)
         })
-        it('throws on null nodeAddresses', () => {
+        it('throws on null nodeIds', () => {
             assert.throws(() => new InstructionMessage({
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: null,
+                nodeIds: null,
                 counter: 1
             }), ValidationError)
         })
@@ -29,7 +29,7 @@ describe('InstructionMessage', () => {
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: null,
-                nodeAddresses: [],
+                nodeIds: [],
                 counter: 1
             }), ValidationError)
         })
@@ -38,7 +38,7 @@ describe('InstructionMessage', () => {
                 requestId: 'requestId',
                 streamId: null,
                 streamPartition: 0,
-                nodeAddresses: [],
+                nodeIds: [],
                 counter: 1
             }), ValidationError)
         })
@@ -47,7 +47,7 @@ describe('InstructionMessage', () => {
                 requestId: null,
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: [],
+                nodeIds: [],
                 counter: 1
             }), ValidationError)
         })
@@ -56,7 +56,7 @@ describe('InstructionMessage', () => {
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: [],
+                nodeIds: [],
                 counter: 1
             })
             assert(msg instanceof InstructionMessage)
@@ -64,7 +64,7 @@ describe('InstructionMessage', () => {
             assert.strictEqual(msg.requestId, 'requestId')
             assert.strictEqual(msg.streamId, 'streamId')
             assert.strictEqual(msg.streamPartition, 0)
-            assert.deepStrictEqual(msg.nodeAddresses, [])
+            assert.deepStrictEqual(msg.nodeIds, [])
             assert.strictEqual(msg.counter, 1)
         })
     })

--- a/test/unit/protocol/tracker_layer/InstructionMessageSerializerV1.test.js
+++ b/test/unit/protocol/tracker_layer/InstructionMessageSerializerV1.test.js
@@ -13,7 +13,7 @@ const message = new InstructionMessage({
     requestId: 'requestId',
     streamId: 'streamId',
     streamPartition: 10,
-    nodeAddresses: ['ws://address-1', 'ws://address-2'],
+    nodeIds: ['node-1', 'node-2'],
     counter: 100
 })
 const serializedMessage = JSON.stringify([
@@ -22,7 +22,7 @@ const serializedMessage = JSON.stringify([
     'requestId',
     'streamId',
     10,
-    ['ws://address-1', 'ws://address-2'],
+    ['node-1', 'node-2'],
     100
 ])
 

--- a/test/unit/protocol/tracker_layer/RelayMessage.test.js
+++ b/test/unit/protocol/tracker_layer/RelayMessage.test.js
@@ -1,0 +1,107 @@
+import assert from 'assert'
+
+import ValidationError from '../../../../src/errors/ValidationError'
+import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
+import RelayMessage from '../../../../src/protocol/tracker_layer/relay_message/RelayMessage'
+
+describe('RelayMessage', () => {
+    describe('constructor', () => {
+        it('throws on null data', () => {
+            assert.throws(() => new RelayMessage({
+                requestId: 'requestId',
+                originator: {
+                    peerId: 'peerId',
+                    peerName: 'peerName',
+                    peerType: 'node'
+                },
+                targetNode: 'targetNode',
+                subType: 'offer',
+                data: null
+            }), ValidationError)
+        })
+        it('throws on null subType', () => {
+            assert.throws(() => new RelayMessage({
+                requestId: 'requestId',
+                originator: {
+                    peerId: 'peerId',
+                    peerName: 'peerName',
+                    peerType: 'node'
+                },
+                targetNode: 'targetNode',
+                subType: null,
+                data: {
+                    hello: 'world'
+                }
+            }), ValidationError)
+        })
+        it('throws on null targetNode', () => {
+            assert.throws(() => new RelayMessage({
+                requestId: 'requestId',
+                originator: {
+                    peerId: 'peerId',
+                    peerName: 'peerName',
+                    peerType: 'node'
+                },
+                targetNode: null,
+                subType: 'offer',
+                data: {
+                    hello: 'world'
+                }
+            }), ValidationError)
+        })
+        it('throws on null originatorId', () => {
+            assert.throws(() => new RelayMessage({
+                requestId: 'requestId',
+                originator: null,
+                targetNode: 'targetNode',
+                subType: 'offer',
+                data: {
+                    hello: 'world'
+                }
+            }), ValidationError)
+        })
+        it('throws on null requestId', () => {
+            assert.throws(() => new RelayMessage({
+                requestId: null,
+                originator: {
+                    peerId: 'peerId',
+                    peerName: 'peerName',
+                    peerType: 'node'
+                },
+                targetNode: 'targetNode',
+                subType: 'offer',
+                data: {
+                    hello: 'world'
+                }
+            }), ValidationError)
+        })
+        it('should create the latest version', () => {
+            const msg = new RelayMessage({
+                requestId: 'requestId',
+                originator: {
+                    peerId: 'peerId',
+                    peerName: 'peerName',
+                    peerType: 'node'
+                },
+                targetNode: 'targetNode',
+                subType: 'offer',
+                data: {
+                    hello: 'world'
+                }
+            })
+            assert(msg instanceof RelayMessage)
+            assert.strictEqual(msg.version, TrackerMessage.LATEST_VERSION)
+            assert.strictEqual(msg.requestId, 'requestId')
+            assert.deepStrictEqual(msg.originator, {
+                peerId: 'peerId',
+                peerName: 'peerName',
+                peerType: 'node'
+            })
+            assert.strictEqual(msg.targetNode, 'targetNode')
+            assert.deepStrictEqual(msg.subType, 'offer')
+            assert.deepStrictEqual(msg.data, {
+                hello: 'world'
+            })
+        })
+    })
+})

--- a/test/unit/protocol/tracker_layer/RelayMessageSerializerV1.test.js
+++ b/test/unit/protocol/tracker_layer/RelayMessageSerializerV1.test.js
@@ -1,0 +1,51 @@
+import assert from 'assert'
+
+import { TrackerLayer } from '../../../../src'
+import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
+
+const { RelayMessage } = TrackerLayer
+
+const VERSION = 1
+
+// Message definitions
+const message = new RelayMessage({
+    requestId: 'requestId',
+    originator: {
+        peerId: 'peerId',
+        peerName: 'peerName',
+        peerType: 'node'
+    },
+    targetNode: 'targetNode',
+    subType: 'offer',
+    data: {
+        hello: 'world'
+    }
+})
+const serializedMessage = JSON.stringify([
+    VERSION,
+    TrackerMessage.TYPES.RelayMessage,
+    'requestId',
+    {
+        peerId: 'peerId',
+        peerName: 'peerName',
+        peerType: 'node'
+    },
+    'targetNode',
+    'offer',
+    {
+        hello: 'world'
+    }
+])
+
+describe('RelayMessageSerializerV1', () => {
+    describe('deserialize', () => {
+        it('correctly parses messages', () => {
+            assert.deepStrictEqual(TrackerMessage.deserialize(serializedMessage), message)
+        })
+    })
+    describe('serialize', () => {
+        it('correctly serializes messages', () => {
+            assert.deepStrictEqual(message.serialize(VERSION), serializedMessage)
+        })
+    })
+})

--- a/test/unit/protocol/tracker_layer/StorageNodesResponse.test.js
+++ b/test/unit/protocol/tracker_layer/StorageNodesResponse.test.js
@@ -6,12 +6,12 @@ import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessag
 
 describe('StorageNodesResponse', () => {
     describe('constructor', () => {
-        it('throws on null nodeAddresses', () => {
+        it('throws on null nodeIds', () => {
             assert.throws(() => new StorageNodesResponse({
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: null
+                nodeIds: null
             }), ValidationError)
         })
         it('throws on null streamPartition', () => {
@@ -19,7 +19,7 @@ describe('StorageNodesResponse', () => {
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: null,
-                nodeAddresses: []
+                nodeIds: []
             }), ValidationError)
         })
         it('throws on null streamId', () => {
@@ -27,7 +27,7 @@ describe('StorageNodesResponse', () => {
                 requestId: 'requestId',
                 streamId: null,
                 streamPartition: 0,
-                nodeAddresses: []
+                nodeIds: []
             }), ValidationError)
         })
         it('throws on null requestId', () => {
@@ -35,7 +35,7 @@ describe('StorageNodesResponse', () => {
                 requestId: null,
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: []
+                nodeIds: []
             }), ValidationError)
         })
         it('should create the latest version', () => {
@@ -43,14 +43,14 @@ describe('StorageNodesResponse', () => {
                 requestId: 'requestId',
                 streamId: 'streamId',
                 streamPartition: 0,
-                nodeAddresses: []
+                nodeIds: []
             })
             assert(msg instanceof StorageNodesResponse)
             assert.strictEqual(msg.version, TrackerMessage.LATEST_VERSION)
             assert.strictEqual(msg.requestId, 'requestId')
             assert.strictEqual(msg.streamId, 'streamId')
             assert.strictEqual(msg.streamPartition, 0)
-            assert.deepStrictEqual(msg.nodeAddresses, [])
+            assert.deepStrictEqual(msg.nodeIds, [])
         })
     })
 })

--- a/test/unit/protocol/tracker_layer/StorageNodesResponseSerializerV1.test.js
+++ b/test/unit/protocol/tracker_layer/StorageNodesResponseSerializerV1.test.js
@@ -13,7 +13,7 @@ const message = new StorageNodesResponse({
     requestId: 'requestId',
     streamId: 'streamId',
     streamPartition: 10,
-    nodeAddresses: ['ws://address-1', 'ws://address-2']
+    nodeIds: ['node-1', 'node-2']
 })
 const serializedMessage = JSON.stringify([
     VERSION,
@@ -21,7 +21,7 @@ const serializedMessage = JSON.stringify([
     'requestId',
     'streamId',
     10,
-    ['ws://address-1', 'ws://address-2']
+    ['node-1', 'node-2']
 ])
 
 describe('StorageNodesResponseSerializerV1', () => {

--- a/test/unit/utils/validations.test.js
+++ b/test/unit/utils/validations.test.js
@@ -4,7 +4,8 @@ import {
     validateIsNotEmptyString,
     validateIsInteger,
     validateIsNotNegativeInteger,
-    validateIsArray
+    validateIsArray,
+    validateIsOneOf
 } from '../../../src/utils/validations'
 import ValidationError from '../../../src/errors/ValidationError'
 
@@ -318,6 +319,43 @@ describe('validations', () => {
         it('does not throw on array', () => {
             expect(() => {
                 validateIsArray('varName', ['a', 'b', 'c', 'd'])
+            }).not.toThrow()
+        })
+    })
+
+    describe('validateIsOneOf', () => {
+        describe('when allowNull = false (default)', () => {
+            it('throws ValidationError on undefined', () => {
+                expect(() => {
+                    validateIsOneOf('varName', undefined, [])
+                }).toThrow(new ValidationError('Expected varName to not be undefined.'))
+            })
+            it('throws ValidationError on null', () => {
+                expect(() => {
+                    validateIsOneOf('varName', null, [])
+                }).toThrow(new ValidationError('Expected varName to not be null.'))
+            })
+        })
+        describe('when allowNull = true', () => {
+            it('does not throw on undefined', () => {
+                expect(() => {
+                    validateIsOneOf('varName', undefined, [], true)
+                }).not.toThrow()
+            })
+            it('does not throw on null', () => {
+                expect(() => {
+                    validateIsOneOf('varName', null, [], true)
+                }).not.toThrow()
+            })
+        })
+        it('throws ValidationError when value not in list', () => {
+            expect(() => {
+                validateIsOneOf('varName', 'not-in-list', ['a', 'b', 'c'])
+            }).toThrow(new ValidationError('Expected varName to be one of ["a","b","c"] but was (not-in-list).'))
+        })
+        it('does not throw on included value', () => {
+            expect(() => {
+                validateIsOneOf('varName', 'b', ['a', 'b', 'c'])
             }).not.toThrow()
         })
     })


### PR DESCRIPTION
Add two new message types to facilitate WebRTC actions.

- `RelayMessage` represents a message that gets sent from one node to another indirectly via a relay (a tracker).
- `ErrorMessage` is sent by tracker to node to signal an error. Error codes are in use for error handling.