### PR TITLE
Handle multiple gaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "6.0.3",
+  "version": "6.0.4-alpha.1",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/test/unit/utils/OrderedMsgChain.test.js
+++ b/test/unit/utils/OrderedMsgChain.test.js
@@ -128,6 +128,34 @@ describe('OrderedMsgChain', () => {
         util.add(msg1)
         util.add(msg3)
     })
+
+    it('can handle multiple gaps', (done) => {
+        const msgs = []
+        util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
+            msgs.push(msg)
+            if (msgs.length === 5) {
+                assert.deepStrictEqual(msgs, [msg1, msg2, msg3, msg4, msg5])
+                done()
+            }
+        }, (from, to) => {
+            if (to.timestamp === 2) {
+                setTimeout(() => {
+                    util.add(msg2)
+                }, 25)
+            }
+            if (to.timestamp === 4) {
+                util.add(msg4)
+            }
+        }, 100, 100)
+        util.on('error', done)
+
+        util.add(msg1)
+        // missing msg2
+        util.add(msg3)
+        // missing msg4
+        util.add(msg5)
+    })
+
     it('call the gap handler MAX_GAP_REQUESTS times and then throws', (done) => {
         let counter = 0
         util = new OrderedMsgChain('publisherId', 'msgChainId', () => {}, (from, to, publisherId, msgChainId) => {


### PR DESCRIPTION
Currently if another gap is created before the current gap is resolved, `OrderedMsgChain` just silently stops working, filling up with queued messages, because it can't find the next message, and it never asks for more gap fills.

Changed this to remove the "if we find the next message all gaps must be filled" assumption.
Now it schedules a gapfill if/whenever it encounters a gap while receiving a new message OR processing the queue.

Also fixed a logging issue where lastReceivedMsgRef would print as NaN.

----

Integration test failure seems unrelated.