### PR TITLE
Don't break if explicitly marking messages out of order.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamr-client-protocol",
-  "version": "7.0.0-alpha.1",
+  "version": "7.0.0-alpha.2",
   "description": "JavaScript classes implementing the Streamr client-to-node protocol",
   "repository": {
     "type": "git",

--- a/src/utils/OrderedMsgChain.js
+++ b/src/utils/OrderedMsgChain.js
@@ -20,6 +20,7 @@ export default class OrderedMsgChain extends EventEmitter {
         propagationTimeout = DEFAULT_PROPAGATION_TIMEOUT, resendTimeout = DEFAULT_RESEND_TIMEOUT,
     ) {
         super()
+        this.markedExplicitly = new WeakSet()
         this.publisherId = publisherId
         this.msgChainId = msgChainId
         this.inOrderHandler = inOrderHandler
@@ -34,9 +35,17 @@ export default class OrderedMsgChain extends EventEmitter {
         /* eslint-enable arrow-body-style */
     }
 
+    isStaleMessage(streamMessage) {
+        const msgRef = streamMessage.getMessageRef()
+        return (
+            this.lastReceivedMsgRef
+            && msgRef.compareTo(this.lastReceivedMsgRef) <= 0
+        )
+    }
+
     add(unorderedStreamMessage) {
-        const msgRef = unorderedStreamMessage.getMessageRef()
-        if (this.lastReceivedMsgRef && msgRef.compareTo(this.lastReceivedMsgRef) <= 0) {
+        if (this.isStaleMessage(unorderedStreamMessage)) {
+            const msgRef = unorderedStreamMessage.getMessageRef()
             // Prevent double-processing of messages for any reason
             debug('Already received message: %o, lastReceivedMsgRef: %o. Ignoring message.', msgRef, this.lastReceivedMsgRef)
             return
@@ -47,22 +56,25 @@ export default class OrderedMsgChain extends EventEmitter {
         } else {
             this.queue.push(unorderedStreamMessage)
         }
+
         this._checkQueue()
     }
 
     markMessageExplicitly(streamMessage) {
-        if (streamMessage) {
-            if (this._isNextMessage(streamMessage)) {
-                this.lastReceivedMsgRef = streamMessage.getMessageRef()
-            }
+        if (!streamMessage || this.isStaleMessage(streamMessage)) {
+            // do nothing if already past/handled this message
+            return
         }
+
+        this.markedExplicitly.add(streamMessage)
+        this.add(streamMessage)
     }
 
     clearGap() {
         this.inProgress = false
+        clearTimeout(this.firstGap)
         clearInterval(this.nextGaps)
         this.nextGaps = undefined
-        clearTimeout(this.firstGap)
         this.firstGap = undefined
     }
 
@@ -92,7 +104,12 @@ export default class OrderedMsgChain extends EventEmitter {
 
     _process(msg) {
         this.lastReceivedMsgRef = msg.getMessageRef()
-        this.inOrderHandler(msg)
+
+        if (this.markedExplicitly.has(msg)) {
+            this.markedExplicitly.delete(msg)
+        } else {
+            this.inOrderHandler(msg)
+        }
     }
 
     _scheduleGap() {
@@ -105,16 +122,20 @@ export default class OrderedMsgChain extends EventEmitter {
         clearTimeout(this.firstGap)
         this.firstGap = setTimeout(() => {
             this._requestGapFill()
-            clearTimeout(this.nextGaps)
+            if (!this.inProgress) { return }
+            clearInterval(this.nextGaps)
             this.nextGaps = setInterval(() => {
-                if (this.inProgress) {
-                    this._requestGapFill()
+                if (!this.inProgress) {
+                    clearInterval(this.nextGaps)
+                    return
                 }
+                this._requestGapFill()
             }, this.resendTimeout)
         }, this.propagationTimeout)
     }
 
     _requestGapFill() {
+        if (!this.inProgress) { return }
         const from = new MessageRef(this.lastReceivedMsgRef.timestamp, this.lastReceivedMsgRef.sequenceNumber + 1)
         const to = this.queue.peek().prevMsgRef
         if (this.gapRequestCount < MAX_GAP_REQUESTS) {

--- a/src/utils/OrderedMsgChain.js
+++ b/src/utils/OrderedMsgChain.js
@@ -107,6 +107,7 @@ export default class OrderedMsgChain extends EventEmitter {
 
         if (this.markedExplicitly.has(msg)) {
             this.markedExplicitly.delete(msg)
+            this.emit('skip', msg)
         } else {
             this.inOrderHandler(msg)
         }

--- a/test/unit/utils/OrderedMsgChain.test.js
+++ b/test/unit/utils/OrderedMsgChain.test.js
@@ -28,9 +28,11 @@ describe('OrderedMsgChain', () => {
     const msg5 = createMsg(5, 0, 4, 0)
     const msg6 = createMsg(6, 0, 5, 0)
     let util
+
     afterEach(() => {
         util.clearGap()
     })
+
     it('handles ordered messages in order', () => {
         const received = []
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
@@ -43,6 +45,7 @@ describe('OrderedMsgChain', () => {
         util.add(msg3)
         assert.deepStrictEqual(received, [msg1, msg2, msg3])
     })
+
     it('drops duplicates', () => {
         const received = []
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
@@ -56,6 +59,7 @@ describe('OrderedMsgChain', () => {
         util.add(msg1)
         assert.deepStrictEqual(received, [msg1, msg2])
     })
+
     it('calls the gap handler', (done) => {
         const received = []
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
@@ -74,6 +78,7 @@ describe('OrderedMsgChain', () => {
         util.add(msg2)
         util.add(msg5)
     })
+
     it('handles unordered messages in order', () => {
         const received = []
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
@@ -86,6 +91,7 @@ describe('OrderedMsgChain', () => {
         util.add(msg4)
         assert.deepStrictEqual(received, [msg1, msg2, msg3, msg4, msg5])
     })
+
     it('handles unchained messages in the order in which they arrive if they are newer', () => {
         const m2 = createMsg(4, 0)
         const m3 = createMsg(17, 0)
@@ -100,6 +106,7 @@ describe('OrderedMsgChain', () => {
         util.add(m4)
         assert.deepStrictEqual(received, [msg1, m2, m3])
     })
+
     it('does not call the gap handler (scheduled but resolved before timeout)', () => {
         const received = []
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
@@ -114,6 +121,7 @@ describe('OrderedMsgChain', () => {
         util.add(msg2)
         assert.deepStrictEqual(received, [msg1, msg2, msg3, msg4, msg5])
     })
+
     it('does not call the gap handler a second time if explicitly cleared', (done) => {
         let counter = 0
         util = new OrderedMsgChain('publisherId', 'msgChainId', () => {}, () => {
@@ -156,6 +164,107 @@ describe('OrderedMsgChain', () => {
         util.add(msg5)
     })
 
+    it('can force-fill multiple gaps', (done) => {
+        const msgs = []
+        const gapHandler = jest.fn((from, to) => {
+            if (to.timestamp === 2) {
+                setTimeout(() => {
+                    util.markMessageExplicitly(msg2)
+                }, 35)
+            }
+            if (to.timestamp === 4) {
+                setTimeout(() => {
+                    util.markMessageExplicitly(msg4)
+                }, 15)
+            }
+        })
+
+        util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
+            msgs.push(msg)
+            if (msgs[msgs.length - 1].getMessageRef().timestamp === 5) {
+                assert.deepStrictEqual(msgs, [msg1, msg3, msg5]) // msg 2 & 3 will be missing
+                expect(gapHandler).toHaveBeenCalledTimes(2)
+                done()
+            }
+        }, gapHandler, 100, 100)
+
+        util.on('error', done)
+
+        util.add(msg1)
+        // missing msg2
+        util.add(msg3)
+        // missing msg4
+        util.add(msg5)
+    })
+
+    it('can force-fill multiple gaps out of order', (done) => {
+        const msgs = []
+        const gapHandler = jest.fn((from, to) => {
+            if (to.timestamp === 2) {
+                util.markMessageExplicitly(msg4)
+                util.markMessageExplicitly(msg2)
+            }
+        })
+
+        util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
+            msgs.push(msg)
+            if (msgs[msgs.length - 1].getMessageRef().timestamp === 5) {
+                assert.deepStrictEqual(msgs, [msg1, msg3, msg5]) // msg 2 & 3 will be missing
+                expect(gapHandler).toHaveBeenCalledTimes(1)
+                done()
+            }
+        }, gapHandler, 100, 100)
+
+        util.on('error', done)
+
+        util.add(msg1)
+        // missing msg2
+        util.add(msg3)
+        // missing msg4
+        util.add(msg5)
+    })
+
+    it('does not hold onto old markMessageExplicitly messages', (done) => {
+        const msgs = []
+        const gapHandler = jest.fn((from, to) => {
+            if (to.timestamp === 2) {
+                util.markMessageExplicitly(msg2)
+                util.markMessageExplicitly(msg4)
+            }
+        })
+
+        util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
+            msgs.push(msg)
+            if (msgs[msgs.length - 1].getMessageRef().timestamp === 5) {
+                util.markMessageExplicitly(msg2)
+                assert.deepStrictEqual(msgs, [msg1, msg3, msg5]) // msg 2 & 3 will be missing
+                assert.deepStrictEqual([
+                    util.markedExplicitly.has(msg1),
+                    util.markedExplicitly.has(msg2),
+                    util.markedExplicitly.has(msg3),
+                    util.markedExplicitly.has(msg4),
+                    util.markedExplicitly.has(msg5),
+                ], [
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                ])
+                expect(gapHandler).toHaveBeenCalledTimes(1)
+                done()
+            }
+        }, gapHandler, 100, 100)
+
+        util.on('error', done)
+
+        util.add(msg1)
+        // missing msg2
+        util.add(msg3)
+        // missing msg4
+        util.add(msg5)
+    })
+
     it('call the gap handler MAX_GAP_REQUESTS times and then throws', (done) => {
         let counter = 0
         util = new OrderedMsgChain('publisherId', 'msgChainId', () => {}, (from, to, publisherId, msgChainId) => {
@@ -175,6 +284,7 @@ describe('OrderedMsgChain', () => {
         util.add(msg1)
         util.add(msg3)
     })
+
     it('after MAX_GAP_REQUESTS OrderingUtil gives up on filling gap ', (done) => {
         const received = []
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
@@ -201,6 +311,7 @@ describe('OrderedMsgChain', () => {
             }
         })
     })
+
     it('handles unordered messages in order (large randomized test)', () => {
         const expected = [msg1]
         let i

--- a/test/unit/utils/OrderedMsgChain.test.js
+++ b/test/unit/utils/OrderedMsgChain.test.js
@@ -206,14 +206,23 @@ describe('OrderedMsgChain', () => {
             }
         })
 
+        const skipped = []
+        const onSkip = jest.fn((msg) => {
+            skipped.push(msg)
+        })
+
         util = new OrderedMsgChain('publisherId', 'msgChainId', (msg) => {
             msgs.push(msg)
             if (msgs[msgs.length - 1].getMessageRef().timestamp === 5) {
                 assert.deepStrictEqual(msgs, [msg1, msg3, msg5]) // msg 2 & 3 will be missing
                 expect(gapHandler).toHaveBeenCalledTimes(1)
+                expect(onSkip).toHaveBeenCalledTimes(2)
+                expect(skipped).toEqual([msg2, msg4])
                 done()
             }
         }, gapHandler, 100, 100)
+
+        util.on('skip', onSkip)
 
         util.on('error', done)
 


### PR DESCRIPTION
Related to previous changes in #46.

Marking messages explicitly does nothing if/when the message is not the next message, which again leads to `OrderedMsgChain` silently breaking (i.e. not requesting gapfill, not handling new messages).

This PR puts explicitly marked messages into the queue and processes them normally, with the exception that they won't be passed to in-order message handler, instead it now emits a 'skip' event for these messages.

