### PR TITLE
Use separate stream id and partition when calling getTracker

### DIFF
--- a/src/utils/TrackerRegistry.js
+++ b/src/utils/TrackerRegistry.js
@@ -17,7 +17,16 @@ class TrackerRegistry {
         this.records.sort()
     }
 
-    getTracker(streamKey) {
+    getTracker(streamId, partition = 0) {
+        if (typeof streamId !== 'string' || streamId.indexOf('::') >= 0) {
+            throw new Error(`invalid id: ${streamId}`)
+        }
+        if (!Number.isInteger(partition) || partition < 0) {
+            throw new Error(`invalid partition: ${partition}`)
+        }
+
+        const streamKey = `${streamId}::${partition}`
+
         return this.records[hashCode(streamKey) % this.records.length]
     }
 

--- a/test/integration/TrackerRegistry.test.js
+++ b/test/integration/TrackerRegistry.test.js
@@ -4,27 +4,6 @@ const contractAddress = '0xBFCF120a8fD17670536f1B27D9737B775b2FD4CF'
 const jsonRpcProvider = 'http://localhost:8545'
 
 describe('TrackerRegistry', () => {
-    test('get array of trackers', async () => {
-        const trackerRegistry = await getTrackerRegistryFromContract({
-            contractAddress, jsonRpcProvider
-        })
-
-        expect(trackerRegistry.getAllTrackers()).toStrictEqual([
-            {
-                http: 'http://10.200.10.1:11111',
-                ws: 'ws://10.200.10.1:30301'
-            },
-            {
-                http: 'http://10.200.10.1:11112',
-                ws: 'ws://10.200.10.1:30302'
-            },
-            {
-                http: 'http://10.200.10.1:11113',
-                ws: 'ws://10.200.10.1:30303'
-            }
-        ])
-    })
-
     test('throw exception if address is wrong (ENS)', async (done) => {
         try {
             await getTrackerRegistryFromContract({
@@ -58,44 +37,105 @@ describe('TrackerRegistry', () => {
         }
     })
 
-    it('get tracker by stream key', async () => {
-        const trackerRegistry = await getTrackerRegistryFromContract({
-            contractAddress, jsonRpcProvider
-        })
+    describe('getAllTrackers', () => {
+        test('get array of trackers', async () => {
+            const trackerRegistry = await getTrackerRegistryFromContract({
+                contractAddress, jsonRpcProvider
+            })
 
-        // 1->1, 2->2, 3->3 coincidence
-        expect(trackerRegistry.getTracker('stream-1::0')).toEqual({
-            http: 'http://10.200.10.1:11111',
-            ws: 'ws://10.200.10.1:30301'
-        })
-        expect(trackerRegistry.getTracker('stream-2::0')).toEqual({
-            http: 'http://10.200.10.1:11112',
-            ws: 'ws://10.200.10.1:30302'
-        })
-        expect(trackerRegistry.getTracker('stream-3::0')).toEqual({
-            http: 'http://10.200.10.1:11113',
-            ws: 'ws://10.200.10.1:30303'
+            expect(trackerRegistry.getAllTrackers()).toStrictEqual([
+                {
+                    http: 'http://10.200.10.1:30301',
+                    ws: 'ws://10.200.10.1:30301'
+                },
+                {
+                    http: 'http://10.200.10.1:30302',
+                    ws: 'ws://10.200.10.1:30302'
+                },
+                {
+                    http: 'http://10.200.10.1:30303',
+                    ws: 'ws://10.200.10.1:30303'
+                }
+            ])
         })
     })
 
-    test('createTrackerRegistry', () => {
-        const trackerRegistry = createTrackerRegistry([{
-            http: 'http://10.200.10.1:11111',
-            ws: 'ws://10.200.10.1:30301'
-        }, {
-            http: 'http://10.200.10.1:11112',
-            ws: 'ws://10.200.10.1:30302'
-        }])
+    describe('getTracker', () => {
+        test('throws if stream id is invalid', async () => {
+            const trackerRegistry = await getTrackerRegistryFromContract({
+                contractAddress, jsonRpcProvider
+            })
 
-        expect(trackerRegistry.getAllTrackers()).toStrictEqual([
-            {
-                http: 'http://10.200.10.1:11111',
+            // old format
+            expect(() => {
+                trackerRegistry.getTracker('stream-1::0')
+            }).toThrow()
+
+            // stream id is not a string
+            expect(() => {
+                trackerRegistry.getTracker(1234)
+            }).toThrow()
+
+            // partition is not valid
+            expect(() => {
+                trackerRegistry.getTracker('stream-1', '0')
+            }).toThrow()
+
+            expect(() => {
+                trackerRegistry.getTracker('stream-1', -23)
+            }).toThrow()
+
+            // valid id
+            expect(() => {
+                trackerRegistry.getTracker('stream-1')
+            }).not.toThrow()
+
+            expect(() => {
+                trackerRegistry.getTracker('stream-1', 5)
+            }).not.toThrow()
+        })
+
+        test('get tracker by stream key', async () => {
+            const trackerRegistry = await getTrackerRegistryFromContract({
+                contractAddress, jsonRpcProvider
+            })
+
+            // 1->1, 2->2, 3->3 coincidence
+            expect(trackerRegistry.getTracker('stream-1')).toEqual({
+                http: 'http://10.200.10.1:30301',
                 ws: 'ws://10.200.10.1:30301'
-            },
-            {
-                http: 'http://10.200.10.1:11112',
+            })
+            expect(trackerRegistry.getTracker('stream-2')).toEqual({
+                http: 'http://10.200.10.1:30302',
                 ws: 'ws://10.200.10.1:30302'
-            }
-        ])
+            })
+            expect(trackerRegistry.getTracker('stream-3')).toEqual({
+                http: 'http://10.200.10.1:30303',
+                ws: 'ws://10.200.10.1:30303'
+            })
+        })
+    })
+
+    describe('createTrackerRegistry', () => {
+        test('creates tracker registry', () => {
+            const trackerRegistry = createTrackerRegistry([{
+                http: 'http://10.200.10.1:30301',
+                ws: 'ws://10.200.10.1:30301'
+            }, {
+                http: 'http://10.200.10.1:30302',
+                ws: 'ws://10.200.10.1:30302'
+            }])
+
+            expect(trackerRegistry.getAllTrackers()).toStrictEqual([
+                {
+                    http: 'http://10.200.10.1:30301',
+                    ws: 'ws://10.200.10.1:30301'
+                },
+                {
+                    http: 'http://10.200.10.1:30302',
+                    ws: 'ws://10.200.10.1:30302'
+                }
+            ])
+        })
     })
 })


### PR DESCRIPTION
Modify `getTracker` so that stream id and partition are passed separately instead of a combined stream key.