### PR TITLE
Proposal to work around contract refactoring

### DIFF
--- a/src/utils/TrackerRegistry.ts
+++ b/src/utils/TrackerRegistry.ts
@@ -59,6 +59,8 @@ async function fetchTrackers(contractAddress: string, jsonRpcProvider: string | 
     }
 
     const result = await contract.getNodes()
+    // The field is tracker.metadata in newer contracts and tracker.url in old contracts.
+    // It's safe to clean up tracker.url when no such contract is used anymore.
     return result.map((tracker: any) => tracker.metadata || tracker.url)
 }
 

--- a/src/utils/TrackerRegistry.ts
+++ b/src/utils/TrackerRegistry.ts
@@ -59,7 +59,7 @@ async function fetchTrackers(contractAddress: string, jsonRpcProvider: string | 
     }
 
     const result = await contract.getNodes()
-    return result.map((tracker: any) => tracker.url)
+    return result.map((tracker: any) => tracker.metadata || tracker.url)
 }
 
 export function createTrackerRegistry<T extends TrackerInfo>(servers: T[]) {


### PR DESCRIPTION
The `url` field will be renamed to `metadata` in structs contained in a [new version](https://github.com/streamr-dev/network-contracts/pull/5) of the tracker registry smart contract. To make the code compatible with both the old and new contract flavour, try both? Ultra-quick proposal submission directly in GitHub, please take over this PR!