### PR TITLE
Convenience: Re-export layer members at top-level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,12 @@ import * as TrackerLayer from "./protocol/tracker_layer/index"
 import * as Errors from "./errors/index"
 import * as Utils from "./utils/index"
 
+export * from "./protocol/control_layer/index"
+export * from "./protocol/message_layer/index"
+export * from "./protocol/tracker_layer/index"
+export * from "./errors/index"
+export * from "./utils/index"
+
 export {
     ControlLayer,
     MessageLayer,

--- a/src/utils/TimestampUtil.ts
+++ b/src/utils/TimestampUtil.ts
@@ -1,4 +1,4 @@
-export function parse(millisOrString: number|string) {
+export default function parse(millisOrString: number|string) {
     if (typeof millisOrString === 'number') {
         return millisOrString
     }
@@ -11,3 +11,5 @@ export function parse(millisOrString: number|string) {
 
     throw new Error(`Invalid timestamp: ${millisOrString}`)
 }
+
+export { parse }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,4 @@
-import * as TimestampUtil from "./TimestampUtil"
+import TimestampUtil from "./TimestampUtil"
 import OrderingUtil from "./OrderingUtil"
 import StreamMessageValidator from "./StreamMessageValidator"
 import CachingStreamMessageValidator from "./CachingStreamMessageValidator"

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,0 +1,18 @@
+import * as Protocol from '../../src'
+
+describe('re-exports', () => {
+    it('re-exports everything', () => {
+        // ensure all sub-modules are exported at top level
+        // and there aren't any duplicates
+        const protocolEntries = Object.values(Protocol)
+        const containers = protocolEntries.filter((value) => typeof value !== 'function')
+        const numKeys = containers.map((value) => Object.keys(value).length).reduce((a, b) => a + b)
+        expect.assertions(numKeys)
+        containers.forEach((container) => {
+            Object.entries(container).forEach(([containerKey, containerValue]) => {
+                // @ts-expect-error
+                expect(Protocol[containerKey]).toBe(containerValue)
+            })
+        })
+    })
+})

--- a/test/unit/protocol/control_layer/BroadcastMessage.test.ts
+++ b/test/unit/protocol/control_layer/BroadcastMessage.test.ts
@@ -1,10 +1,7 @@
 import assert from 'assert'
 
 import ValidationError from '../../../../src/errors/ValidationError'
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage, MessageID } = MessageLayer
-const { BroadcastMessage, ControlMessage } = ControlLayer
+import { StreamMessage, MessageID, BroadcastMessage, ControlMessage } from '../../../../src/index'
 
 describe('BroadcastMessage', () => {
     describe('constructor', () => {

--- a/test/unit/protocol/control_layer/BroadcastMessageSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/BroadcastMessageSerializerV1.test.ts
@@ -1,10 +1,7 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
+import { StreamMessage, BroadcastMessage, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
-
-const { StreamMessage } = MessageLayer
-const { BroadcastMessage, ControlMessage } = ControlLayer
 
 const streamMessage = StreamMessage.deserialize([30, ['streamId', 0, 1529549961116, 0, 'address', 'msg-chain-id'],
     [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH, 'signature'])

--- a/test/unit/protocol/control_layer/BroadcastMessageSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/BroadcastMessageSerializerV2.test.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage } = MessageLayer
-const { BroadcastMessage, ControlMessage } = ControlLayer
+import { StreamMessage, BroadcastMessage, ControlMessage } from '../../../../src/index'
 
 const streamMessage = StreamMessage.deserialize([30, ['streamId', 0, 1529549961116, 0, 'address', 'msg-chain-id'],
     [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH, 'signature'])

--- a/test/unit/protocol/control_layer/ErrorResponseSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ErrorResponseSerializerV1.test.ts
@@ -1,10 +1,8 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
+import { ErrorResponse, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
 import { ErrorCode } from '../../../../src/protocol/control_layer/error_response/ErrorResponse'
-
-const { ErrorResponse, ControlMessage } = ControlLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ErrorResponseSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ErrorResponseSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ErrorResponse, ControlMessage } = ControlLayer
+import { ErrorResponse, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/PublishRequest.test.ts
+++ b/test/unit/protocol/control_layer/PublishRequest.test.ts
@@ -1,10 +1,7 @@
 import assert from 'assert'
 
 import ValidationError from '../../../../src/errors/ValidationError'
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage, MessageID } = MessageLayer
-const { PublishRequest, ControlMessage } = ControlLayer
+import { StreamMessage, MessageID, PublishRequest, ControlMessage } from '../../../../src/index'
 
 describe('PublishRequest', () => {
     const streamMessage = new StreamMessage({

--- a/test/unit/protocol/control_layer/PublishRequestSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/PublishRequestSerializerV1.test.ts
@@ -1,10 +1,7 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
+import { StreamMessage, PublishRequest, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
-
-const { StreamMessage } = MessageLayer
-const { PublishRequest, ControlMessage } = ControlLayer
 
 const streamMessage = StreamMessage.deserialize([30, ['streamId', 0, 1529549961116, 0, 'address', 'msg-chain-id'],
     [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH, 'signature'])

--- a/test/unit/protocol/control_layer/PublishRequestSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/PublishRequestSerializerV2.test.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage } = MessageLayer
-const { PublishRequest, ControlMessage } = ControlLayer
+import { StreamMessage, PublishRequest, ControlMessage } from '../../../../src/index'
 
 const streamMessage = StreamMessage.deserialize([30, ['streamId', 0, 1529549961116, 0, 'address', 'msg-chain-id'],
     [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH, 'signature'])

--- a/test/unit/protocol/control_layer/ResendFromRequestSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ResendFromRequestSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
 import MessageRef from '../../../../src/protocol/message_layer/MessageRef'
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendFromRequest, ControlMessage } = ControlLayer
+import { ResendFromRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ResendFromRequestSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ResendFromRequestSerializerV2.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
 import MessageRef from '../../../../src/protocol/message_layer/MessageRef'
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendFromRequest, ControlMessage } = ControlLayer
+import { ResendFromRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/ResendLastRequestSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ResendLastRequestSerializerV1.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendLastRequest, ControlMessage } = ControlLayer
+import { ResendLastRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ResendLastRequestSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ResendLastRequestSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendLastRequest, ControlMessage } = ControlLayer
+import { ResendLastRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/ResendRangeRequestSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ResendRangeRequestSerializerV1.test.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { MessageRef } = MessageLayer
-const { ResendRangeRequest, ControlMessage } = ControlLayer
+import { MessageRef, ResendRangeRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ResendRangeRequestSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ResendRangeRequestSerializerV2.test.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { MessageRef } = MessageLayer
-const { ResendRangeRequest, ControlMessage } = ControlLayer
+import { MessageRef, ResendRangeRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/ResendResponseNoResendSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ResendResponseNoResendSerializerV1.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendResponseNoResend, ControlMessage } = ControlLayer
+import { ResendResponseNoResend, ControlMessage } from '../../../../src/index'
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ResendResponseNoResendSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ResendResponseNoResendSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendResponseNoResend, ControlMessage } = ControlLayer
+import { ResendResponseNoResend, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/ResendResponseResendingSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ResendResponseResendingSerializerV1.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendResponseResending, ControlMessage } = ControlLayer
+import { ResendResponseResending, ControlMessage  } from '../../../../src/index'
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ResendResponseResendingSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ResendResponseResendingSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendResponseResending, ControlMessage } = ControlLayer
+import { ResendResponseResending, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/ResendResponseResentSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/ResendResponseResentSerializerV1.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendResponseResent, ControlMessage } = ControlLayer
+import { ResendResponseResent, ControlMessage } from '../../../../src/index'
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/ResendResponseResentSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/ResendResponseResentSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { ResendResponseResent, ControlMessage } = ControlLayer
+import { ResendResponseResent, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/SubscribeRequestSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/SubscribeRequestSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
+import { SubscribeRequest, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
-
-const { SubscribeRequest, ControlMessage } = ControlLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/SubscribeRequestSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/SubscribeRequestSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { SubscribeRequest, ControlMessage } = ControlLayer
+import { SubscribeRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/SubscribeResponseSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/SubscribeResponseSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
+import { SubscribeResponse, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
-
-const { SubscribeResponse, ControlMessage } = ControlLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/SubscribeResponseSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/SubscribeResponseSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { SubscribeResponse, ControlMessage } = ControlLayer
+import { SubscribeResponse, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/UnicastMessage.test.ts
+++ b/test/unit/protocol/control_layer/UnicastMessage.test.ts
@@ -1,10 +1,7 @@
 import assert from 'assert'
 
 import ValidationError from '../../../../src/errors/ValidationError'
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage, MessageID } = MessageLayer
-const { UnicastMessage, ControlMessage } = ControlLayer
+import { StreamMessage, MessageID,  UnicastMessage, ControlMessage } from '../../../../src/index'
 
 describe('UnicastMessage', () => {
     describe('constructor', () => {

--- a/test/unit/protocol/control_layer/UnicastMessageSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/UnicastMessageSerializerV1.test.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage } = MessageLayer
-const { UnicastMessage, ControlMessage } = ControlLayer
+import { StreamMessage, UnicastMessage, ControlMessage } from '../../../../src/index'
 
 const streamMessage = StreamMessage.deserialize([30, ['streamId', 0, 1529549961116, 0, 'address', 'msg-chain-id'],
     [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH, 'signature'])

--- a/test/unit/protocol/control_layer/UnicastMessageSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/UnicastMessageSerializerV2.test.ts
@@ -1,9 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer, MessageLayer } from '../../../../src/index'
-
-const { StreamMessage } = MessageLayer
-const { UnicastMessage, ControlMessage } = ControlLayer
+import { StreamMessage, UnicastMessage, ControlMessage } from '../../../../src/index'
 
 const streamMessage = StreamMessage.deserialize([30, ['streamId', 0, 1529549961116, 0, 'address', 'msg-chain-id'],
     [1529549961000, 0], StreamMessage.MESSAGE_TYPES.MESSAGE, '{"valid": "json"}', StreamMessage.SIGNATURE_TYPES.ETH, 'signature'])

--- a/test/unit/protocol/control_layer/UnsubscribeRequestSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/UnsubscribeRequestSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
+import { UnsubscribeRequest, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
-
-const { UnsubscribeRequest, ControlMessage } = ControlLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/UnsubscribeRequestSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/UnsubscribeRequestSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { UnsubscribeRequest, ControlMessage } = ControlLayer
+import { UnsubscribeRequest, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/control_layer/UnsubscribeResponseSerializerV1.test.ts
+++ b/test/unit/protocol/control_layer/UnsubscribeResponseSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
+import { UnsubscribeResponse, ControlMessage } from '../../../../src/index'
 import { PLACEHOLDER_REQUEST_ID_PROTOCOL_V1 } from '../../../../src/protocol/control_layer/ControlMessage'
-
-const { UnsubscribeResponse, ControlMessage } = ControlLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/control_layer/UnsubscribeResponseSerializerV2.test.ts
+++ b/test/unit/protocol/control_layer/UnsubscribeResponseSerializerV2.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { ControlLayer } from '../../../../src/index'
-
-const { UnsubscribeResponse, ControlMessage } = ControlLayer
+import { UnsubscribeResponse, ControlMessage } from '../../../../src/index'
 
 const VERSION = 2
 

--- a/test/unit/protocol/message_layer/GroupKeyAnnounce.test.ts
+++ b/test/unit/protocol/message_layer/GroupKeyAnnounce.test.ts
@@ -1,11 +1,7 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
+import { StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyAnnounce } from '../../../../src/index'
 import EncryptedGroupKey from '../../../../src/protocol/message_layer/EncryptedGroupKey'
-
-const {
-    StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyAnnounce
-} = MessageLayer
 
 // Message definitions
 const message = new GroupKeyAnnounce({

--- a/test/unit/protocol/message_layer/GroupKeyErrorResponse.test.ts
+++ b/test/unit/protocol/message_layer/GroupKeyErrorResponse.test.ts
@@ -1,11 +1,10 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
-import { ErrorCode } from '../../../../src/protocol/message_layer/GroupKeyErrorResponse'
-
-const {
+import {
     StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyErrorResponse
-} = MessageLayer
+} from '../../../../src/index'
+
+import { ErrorCode } from '../../../../src/protocol/message_layer/GroupKeyErrorResponse'
 
 // Message definitions
 const message = new GroupKeyErrorResponse({

--- a/test/unit/protocol/message_layer/GroupKeyRequest.test.ts
+++ b/test/unit/protocol/message_layer/GroupKeyRequest.test.ts
@@ -1,10 +1,6 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
-
-const {
-    StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyRequest
-} = MessageLayer
+import { StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyRequest } from '../../../../src/index'
 
 // Message definitions
 const message = new GroupKeyRequest({

--- a/test/unit/protocol/message_layer/GroupKeyResponse.test.ts
+++ b/test/unit/protocol/message_layer/GroupKeyResponse.test.ts
@@ -1,11 +1,7 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
+import { StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyResponse } from '../../../../src/index'
 import EncryptedGroupKey from '../../../../src/protocol/message_layer/EncryptedGroupKey'
-
-const {
-    StreamMessage, MessageID, MessageRef, GroupKeyMessage, GroupKeyResponse
-} = MessageLayer
 
 // Message definitions
 const message = new GroupKeyResponse({

--- a/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -2,13 +2,11 @@ import assert from 'assert'
 
 import sinon from 'sinon'
 
-import { MessageLayer } from '../../../../src/index'
+import { MessageRef, MessageIDStrict, EncryptedGroupKey } from '../../../../src/index'
 import ValidationError from '../../../../src/errors/ValidationError'
 import UnsupportedVersionError from '../../../../src/errors/UnsupportedVersionError'
 import { Serializer } from '../../../../src/Serializer'
 import StreamMessage from '../../../../src/protocol/message_layer/StreamMessage'
-
-const { MessageRef, MessageIDStrict, EncryptedGroupKey } = MessageLayer
 
 const content = {
     hello: 'world',

--- a/test/unit/protocol/message_layer/StreamMessageSerializerV30.test.ts
+++ b/test/unit/protocol/message_layer/StreamMessageSerializerV30.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
-
-const { StreamMessage, MessageRef, MessageID } = MessageLayer
+import { StreamMessage, MessageRef, MessageID } from '../../../../src/index'
 
 const VERSION = 30
 

--- a/test/unit/protocol/message_layer/StreamMessageSerializerV31.test.ts
+++ b/test/unit/protocol/message_layer/StreamMessageSerializerV31.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
-
-const { StreamMessage, MessageRef, MessageIDStrict } = MessageLayer
+import { StreamMessage, MessageRef, MessageIDStrict } from '../../../../src/index'
 
 const VERSION = 31
 

--- a/test/unit/protocol/message_layer/StreamMessageSerializerV32.test.ts
+++ b/test/unit/protocol/message_layer/StreamMessageSerializerV32.test.ts
@@ -1,8 +1,6 @@
 import assert from 'assert'
 
-import { MessageLayer } from '../../../../src/index'
-
-const { StreamMessage, MessageRef, MessageIDStrict, EncryptedGroupKey } = MessageLayer
+import { StreamMessage, MessageRef, MessageIDStrict, EncryptedGroupKey } from '../../../../src/index'
 
 const VERSION = 32
 

--- a/test/unit/protocol/tracker_layer/RelayMessageSerializerV1.test.ts
+++ b/test/unit/protocol/tracker_layer/RelayMessageSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { TrackerLayer } from '../../../../src'
+import { RelayMessage } from '../../../../src'
 import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
-
-const { RelayMessage } = TrackerLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/tracker_layer/StatusMessageSerializerV1.test.ts
+++ b/test/unit/protocol/tracker_layer/StatusMessageSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { TrackerLayer } from '../../../../src'
+import { StatusMessage } from '../../../../src'
 import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
-
-const { StatusMessage } = TrackerLayer
 
 const VERSION = 1
 

--- a/test/unit/protocol/tracker_layer/StorageNodesResponseSerializerV1.test.ts
+++ b/test/unit/protocol/tracker_layer/StorageNodesResponseSerializerV1.test.ts
@@ -1,9 +1,7 @@
 import assert from 'assert'
 
-import { TrackerLayer } from '../../../../src'
+import { StorageNodesResponse } from '../../../../src'
 import TrackerMessage from '../../../../src/protocol/tracker_layer/TrackerMessage'
-
-const { StorageNodesResponse } = TrackerLayer
 
 const VERSION = 1
 

--- a/test/unit/utils/OrderingUtil.test.ts
+++ b/test/unit/utils/OrderingUtil.test.ts
@@ -2,12 +2,10 @@ import assert from 'assert'
 
 import shuffle from 'array-shuffle'
 
-import { MessageLayer } from '../../../src'
+import { MessageID } from '../../../src'
 import OrderingUtil from '../../../src/utils/OrderingUtil'
 import StreamMessage from '../../../src/protocol/message_layer/StreamMessage'
 import MessageRef from '../../../src/protocol/message_layer/MessageRef'
-
-const { MessageID } = MessageLayer
 
 const createMsg = (
     timestamp = 1, sequenceNumber = 0, prevTimestamp: number | null = null,

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 
 import sinon from 'sinon'
 
-import { Utils } from '../../../src'
+import { StreamMessageValidator, SigningUtil } from '../../../src'
 import StreamMessage from '../../../src/protocol/message_layer/StreamMessage'
 import MessageID from '../../../src/protocol/message_layer/MessageID'
 import GroupKeyRequest from '../../../src/protocol/message_layer/GroupKeyRequest'
@@ -12,8 +12,6 @@ import GroupKeyErrorResponse, { ErrorCode } from '../../../src/protocol/message_
 import EncryptedGroupKey from '../../../src/protocol/message_layer/EncryptedGroupKey'
 import ValidationError from '../../../src/errors/ValidationError'
 import { StreamMetadata } from '../../../src/utils/StreamMessageValidator'
-
-const { StreamMessageValidator, SigningUtil } = Utils
 
 describe('StreamMessageValidator', () => {
     let getStream: (streamId: string) => Promise<StreamMetadata>


### PR DESCRIPTION
Currently if you want to use + type `StreamMessage`, you have to do it in two steps:
1. `import { MessageLayer }` then
2.  destructure `StreamMessage` from `MessageLayer`

and also fully reference `MessageLayer.StreamMessage` for types:

```ts
import { MessageLayer } from 'streamr-client-protocol'
const { StreamMessage } = MessageLayer
// but then also needing to do this:
const streamMessage: MessageLayer.StreamMessage // can't use `StreamMessage` or `typeof StreamMessage`
```

This is rather inconvenient.

With this PR, everything is exported at the top level, so now you can import/type things like `StreamMessage` directly:
```typescript
import { StreamMessage } from 'streamr-client-protocol'
const streamMessage: StreamMessage
```

or just import the type directly if you aren't referencing `StreamMessage` outside types:

```typescript
import type { StreamMessage } from 'streamr-client-protocol'
const streamMessage: StreamMessage
```

All without pulling in `MessageLayer` first.

Old top-level exports still exist:

```js
['ControlLayer', 'MessageLayer', 'TrackerLayer', 'Errors', 'Utils']
```

But now there's also everything else as well:

```js
    [
      'BroadcastMessage',
      'ErrorResponse',
      'PublishRequest',
      'ResendFromRequest',
      'ResendLastRequest',
      'ResendRangeRequest',
      'ResendResponseNoResend',
      'ResendResponseResending',
      'ResendResponseResent',
      'SubscribeRequest',
      'SubscribeResponse',
      'UnicastMessage',
      'UnsubscribeRequest',
      'UnsubscribeResponse',
      'ControlMessage',
      'MessageID',
      'MessageIDStrict',
      'MessageRef',
      'MessageRefStrict',
      'StreamMessage',
      'GroupKeyMessage',
      'GroupKeyRequest',
      'GroupKeyResponse',
      'GroupKeyAnnounce',
      'GroupKeyErrorResponse',
      'EncryptedGroupKey',
      'InstructionMessage',
      'ErrorMessage',
      'RelayMessage',
      'StatusMessage',
      'StorageNodesRequest',
      'StorageNodesResponse',
      'TrackerMessage',
      'InvalidJsonError',
      'UnsupportedVersionError',
      'GapFillFailedError',
      'ValidationError',
      'TimestampUtil',
      'OrderingUtil',
      'StreamMessageValidator',
      'CachingStreamMessageValidator',
      'SigningUtil',
      'TrackerRegistry',
      'createTrackerRegistry',
      'getTrackerRegistryFromContract'
    ]
```