### PR TITLE
Use streamr-docker-dev-action in CI.

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -37,12 +37,10 @@ jobs:
       - name: test-unit
         run: npm run test-unit
 
-      - name: setup streamr-docker-dev
-        run: |
-          git clone --depth 1 https://github.com/streamr-dev/streamr-docker-dev.git
-          sudo ifconfig docker0 10.200.10.1/24
-          ${GITHUB_WORKSPACE}/streamr-docker-dev/streamr-docker-dev/bin.sh start parity-node0 --wait
-
+      - name: Start Streamr Docker Stack
+        uses: streamr-dev/streamr-docker-dev-action@v1.0.0-alpha.3
+        with:
+          services-to-start: "parity-sidechain-node0"
       - name: test-integration
         run: npm run test-integration
 


### PR DESCRIPTION
Current setup is failing in CI due to `ifconfig: command not found`
Swapped out manual `git clone` to use `streamr-docker-dev-action@v1.0.0-alpha.3` which fixes this.