### PR TITLE
implement prototype of log-friendly toString

### DIFF
--- a/src/protocol/control_layer/broadcast_message/BroadcastMessage.ts
+++ b/src/protocol/control_layer/broadcast_message/BroadcastMessage.ts
@@ -1,6 +1,7 @@
 import ControlMessage, { ControlMessageOptions } from '../ControlMessage'
 import { validateIsType } from '../../../utils/validations'
 import StreamMessage from '../../message_layer/StreamMessage'
+import { formLogFriendlyString } from "../../helpers"
 
 export interface Options extends ControlMessageOptions {
     streamMessage: StreamMessage
@@ -15,5 +16,14 @@ export default class BroadcastMessage extends ControlMessage {
 
         validateIsType('streamMessage', streamMessage, 'StreamMessage', StreamMessage)
         this.streamMessage = streamMessage
+    }
+
+
+    toString(): string {
+        return formLogFriendlyString(
+            this.constructor.name, false,
+            'requestId', this.requestId,
+            'streamMessage', this.streamMessage
+        )
     }
 }

--- a/src/protocol/control_layer/error_response/ErrorResponse.ts
+++ b/src/protocol/control_layer/error_response/ErrorResponse.ts
@@ -1,5 +1,6 @@
 import ControlMessage, { ControlMessageOptions } from '../ControlMessage'
 import { validateIsString } from '../../../utils/validations'
+import { formLogFriendlyString } from "../../helpers"
 
 export enum ErrorCode {
     INVALID_REQUEST = 'INVALID_REQUEST',
@@ -34,5 +35,14 @@ export default class ErrorResponse extends ControlMessage {
             validateIsString('errorCode', errorCode)
         }
         this.errorCode = errorCode
+    }
+
+    toString(): string {
+        return formLogFriendlyString(
+            this.constructor.name, false,
+            'requestId', this.requestId,
+            'errorMessage', this.errorMessage,
+            'errorCode', this.errorCode
+        )
     }
 }

--- a/src/protocol/helpers.ts
+++ b/src/protocol/helpers.ts
@@ -1,0 +1,33 @@
+function formatValue(value: any): string {
+    if (Array.isArray(value)) {
+        return '[' + value.map((v) => formatValue(v)).join(',') + ']'
+    } else if (!isNaN(value)) {
+        return value.toString()
+    } else {
+        return `'${value}'`
+    }
+
+}
+
+/**
+ * Form a log-friendly string representation of a message
+ * @param className -- name of the message class
+ * @param addEndingDots -- whether to add "..." at the end of the body, signalling that some values are not shown
+ * @param args -- pairs of (key, value) to print out, .e.g, ['streamId', '7wa7APtlTq6EC5iTCBy6dw'] => streamId='7wa7APtlTq6EC5iTCBy6dw'
+ */
+export function formLogFriendlyString(className: string, addEndingDots: boolean, ...args: any[]) {
+    if (args.length % 2 !== 0) {
+        throw new Error(`even amount of rest arguments required (got ${args.length})`)
+    }
+    let body = ''
+    for (let i = 0; i < args.length - 1; i += 2) {
+        const key = args[i].toString()
+        const value =  formatValue(args[i+1])
+        const delimiter = i < args.length - 3 ? ', ' : ''
+        body += `${key}=${value}${delimiter}`
+    }
+    if (addEndingDots) {
+        body += ', ...'
+    }
+    return `${className}{${body}}`
+}

--- a/src/protocol/message_layer/StreamMessage.ts
+++ b/src/protocol/message_layer/StreamMessage.ts
@@ -7,6 +7,7 @@ import MessageRef from './MessageRef'
 import MessageID from './MessageID'
 import EncryptedGroupKey from './EncryptedGroupKey'
 import { Serializer } from '../../Serializer'
+import { formLogFriendlyString } from "../helpers"
 
 const serializerByVersion: {[version: string]: Serializer<StreamMessage> } = {}
 const BYE_KEY = '_bye'
@@ -349,5 +350,16 @@ export default class StreamMessage {
             signatureType: this.signatureType,
             signature: this.signature,
         }
+    }
+
+    toString(): string {
+        return formLogFriendlyString(
+            this.constructor.name, true,
+            'streamId', this.getStreamId(),
+            'streamPartition', this.getStreamPartition(),
+            'timestamp', this.getTimestamp(),
+            'sequenceNumber', this.getSequenceNumber(),
+            'publisherId', this.getPublisherId()
+        )
     }
 }

--- a/src/protocol/tracker_layer/instruction_message/InstructionMessage.ts
+++ b/src/protocol/tracker_layer/instruction_message/InstructionMessage.ts
@@ -4,6 +4,7 @@ import {
     validateIsArray
 } from '../../../utils/validations'
 import TrackerMessage, { TrackerMessageOptions } from '../TrackerMessage'
+import { formLogFriendlyString } from "../../helpers"
 
 export interface Options extends TrackerMessageOptions {
     streamId: string
@@ -31,5 +32,16 @@ export default class InstructionMessage extends TrackerMessage {
         this.streamPartition = streamPartition
         this.nodeIds = nodeIds
         this.counter = counter
+    }
+
+    toString(): string {
+        return formLogFriendlyString(
+            this.constructor.name, false,
+            'requestId', this.requestId,
+            'streamId', this.streamId,
+            'streamPartition', this.streamPartition,
+            'nodeIds', this.nodeIds,
+            'counter', this.counter
+        )
     }
 }

--- a/test/unit/protocol/control_layer/BroadcastMessage.test.ts
+++ b/test/unit/protocol/control_layer/BroadcastMessage.test.ts
@@ -33,4 +33,19 @@ describe('BroadcastMessage', () => {
             assert.strictEqual(msg.streamMessage, streamMessage)
         })
     })
+
+    describe('toString', () => {
+        it('provides a log-friendly format', () => {
+            const streamMessage = new StreamMessage({
+                messageId: new MessageID('streamId', 0, 1529549961116, 0, 'publisherId', 'msgChainId'),
+                content: {},
+            })
+            const msg = new BroadcastMessage({
+                requestId: 'requestId',
+                streamMessage,
+            })
+            expect(msg.toString())
+                .toEqual(`BroadcastMessage{requestId='requestId', streamMessage='${streamMessage.toString()}'}`)
+        })
+    })
 })

--- a/test/unit/protocol/control_layer/ErrorResponse.test.ts
+++ b/test/unit/protocol/control_layer/ErrorResponse.test.ts
@@ -3,6 +3,7 @@ import assert from 'assert'
 import ErrorResponse, { ErrorCode } from '../../../../src/protocol/control_layer/error_response/ErrorResponse'
 import ControlMessage from '../../../../src/protocol/control_layer/ControlMessage'
 import ValidationError from '../../../../src/errors/ValidationError'
+import { MessageID, StreamMessage } from "../../../../src"
 
 describe('ErrorResponse', () => {
     describe('constructor', () => {
@@ -37,6 +38,18 @@ describe('ErrorResponse', () => {
             assert.strictEqual(msg.version, ControlMessage.LATEST_VERSION)
             assert.strictEqual(msg.errorMessage, 'error message')
             assert.strictEqual(msg.errorCode, ErrorCode.NOT_FOUND)
+        })
+    })
+
+    describe('toString', () => {
+        it('provides a log-friendly format', () => {
+            const msg = new ErrorResponse({
+                requestId: 'requestId',
+                errorMessage: 'Authentication failed.',
+                errorCode: ErrorCode.AUTHENTICATION_FAILED,
+            })
+            expect(msg.toString())
+                .toEqual(`ErrorResponse{requestId='requestId', errorMessage='Authentication failed.', errorCode='AUTHENTICATION_FAILED'}`)
         })
     })
 })

--- a/test/unit/protocol/message_layer/StreamMessage.test.ts
+++ b/test/unit/protocol/message_layer/StreamMessage.test.ts
@@ -277,4 +277,11 @@ describe('StreamMessage', () => {
             assert(StreamMessage.getSupportedVersions().indexOf(999) < 0)
         })
     })
+
+    describe('toString', () => {
+        it('provides a log-friendly format', () => {
+            expect(msg().toString())
+                .toEqual(`StreamMessage{streamId='streamId', streamPartition=0, timestamp=1564046332168, sequenceNumber=10, publisherId='publisherId', ...}`)
+        })
+    })
 })

--- a/test/unit/protocol/tracker_layer/InstructionMessage.test.ts
+++ b/test/unit/protocol/tracker_layer/InstructionMessage.test.ts
@@ -68,4 +68,18 @@ describe('InstructionMessage', () => {
             assert.strictEqual(msg.counter, 1)
         })
     })
+
+    describe('toString', () => {
+        it('provides a log-friendly format', () => {
+            const msg = new InstructionMessage({
+                requestId: 'requestId',
+                streamId: 'streamId',
+                streamPartition: 0,
+                nodeIds: ['node-1', 'node-2'],
+                counter: 1
+            })
+            expect(msg.toString())
+                .toEqual("InstructionMessage{requestId='requestId', streamId='streamId', streamPartition=0, nodeIds=['node-1','node-2'], counter=1}")
+        })
+    })
 })


### PR DESCRIPTION
## Description 
Implement method `toString()` on message classes to print message metadata in a log-friendly format.

E.g.
```ts
instructionMessage.toString()
// InstructionMessage{requestId='requestId', streamId='streamId', streamPartition=0, nodeIds=['node-1','node-2'], counter=1}
```

```ts
streamMessage.toString()
// StreamMessage{streamId='streamId', streamPartition=0, timestamp=1564046332168, sequenceNumber=10, publisherId='publisherId', ...}
```

## Motivation

I've been looking into redoing the logging of the network project. Whilst at it, I noticed we often have a need to log the metadata of messages. We often end up doing something as follows:
```ts
this.logger.debug('instruction %j (counter=%d, stream=%s, requestId=%s) sent to node %s',
                            newNeighbors, counterValue, streamKey, nodeId)
``` 
Whilst that's not too bad, it could be a nice feature to be able to just do
```ts
this.logger.debug('instruction %s sent to node %s', instructionMessage, nodeId)
```

The logging format is something that IntelliJ autogenerates for Java classes, and I have found it to be quite readable in practice in the past.

### Caveats
Obviously, it's quite hard to design a one-size-fits all logging format. Here, for example, I've opted to leave out some fields of the `StreamMessage` that may be very relevant in certain contexts (e.g. encryption / decryption related fields) but not in others. One option would be to include all fields regardless, but I do think that the brevity of logs is something of value as well.  Perhaps it is indeed appropriate to customize what fields are logged based on the situation, but OTOH, it would be nice to have a default of some sort?