### PR TITLE
NET-86: Add a way to toggle on strict (Brubeck) validation

### DIFF
--- a/src/utils/StreamMessageValidator.ts
+++ b/src/utils/StreamMessageValidator.ts
@@ -164,14 +164,16 @@ export default class StreamMessageValidator {
             throw new ValidationError(`Partition ${streamMessage.getStreamPartition()} is out of range (0..${stream.partitions - 1}). Message: ${streamMessage.serialize()}`)
         }
 
-        // Cryptographic integrity and publisher permission checks. Note that only signed messages can be validated this way.
-        await StreamMessageValidator.assertSignatureIsValid(streamMessage, this.verify)
-        const sender = streamMessage.getPublisherId()
+        if (streamMessage.signature) {
+            // Cryptographic integrity and publisher permission checks. Note that only signed messages can be validated this way.
+            await StreamMessageValidator.assertSignatureIsValid(streamMessage, this.verify)
+            const sender = streamMessage.getPublisherId()
 
-        // Check that the sender of the message is a valid publisher of the stream
-        const senderIsPublisher = await this.isPublisher(sender, streamMessage.getStreamId())
-        if (!senderIsPublisher) {
-            throw new ValidationError(`${sender} is not a publisher on stream ${streamMessage.getStreamId()}. Message: ${streamMessage.serialize()}`)
+            // Check that the sender of the message is a valid publisher of the stream
+            const senderIsPublisher = await this.isPublisher(sender, streamMessage.getStreamId())
+            if (!senderIsPublisher) {
+                throw new ValidationError(`${sender} is not a publisher on stream ${streamMessage.getStreamId()}. Message: ${streamMessage.serialize()}`)
+            }
         }
     }
 

--- a/src/utils/StreamMessageValidator.ts
+++ b/src/utils/StreamMessageValidator.ts
@@ -140,26 +140,26 @@ export default class StreamMessageValidator {
         const stream = await this.getStream(streamMessage.getStreamId())
 
         // Checks against stream metadata
-        if (stream.requireSignedData && !streamMessage.signature) {
-            throw new ValidationError(`This stream requires data to be signed. Message: ${streamMessage.serialize()}`)
+        if (!streamMessage.signature) {
+            throw new ValidationError(`Stream data is required to be signed. Message: ${streamMessage.serialize()}`)
         }
         if (stream.requireEncryptedData && streamMessage.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE) {
             throw new ValidationError(`This stream requires data to be encrypted. Message: ${streamMessage.serialize()}`)
         }
+
+        // console.log('stream', stream.)
         if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= stream.partitions) {
             throw new ValidationError(`Partition ${streamMessage.getStreamPartition()} is out of range (0..${stream.partitions - 1}). Message: ${streamMessage.serialize()}`)
         }
 
         // Cryptographic integrity and publisher permission checks. Note that only signed messages can be validated this way.
-        if (streamMessage.signature) {
-            await StreamMessageValidator.assertSignatureIsValid(streamMessage, this.verify)
-            const sender = streamMessage.getPublisherId()
+        await StreamMessageValidator.assertSignatureIsValid(streamMessage, this.verify)
+        const sender = streamMessage.getPublisherId()
 
-            // Check that the sender of the message is a valid publisher of the stream
-            const senderIsPublisher = await this.isPublisher(sender, streamMessage.getStreamId())
-            if (!senderIsPublisher) {
-                throw new ValidationError(`${sender} is not a publisher on stream ${streamMessage.getStreamId()}. Message: ${streamMessage.serialize()}`)
-            }
+        // Check that the sender of the message is a valid publisher of the stream
+        const senderIsPublisher = await this.isPublisher(sender, streamMessage.getStreamId())
+        if (!senderIsPublisher) {
+            throw new ValidationError(`${sender} is not a publisher on stream ${streamMessage.getStreamId()}. Message: ${streamMessage.serialize()}`)
         }
     }
 

--- a/src/utils/StreamMessageValidator.ts
+++ b/src/utils/StreamMessageValidator.ts
@@ -153,7 +153,10 @@ export default class StreamMessageValidator {
             throw new ValidationError(`Stream data is required to be signed. Message: ${streamMessage.serialize()}`)
         }
 
-        if ((stream.requireEncryptedData || this.requireEncryptedData) && stream.requireEncryptedData && streamMessage.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE) {
+        if (
+            (stream.requireEncryptedData || this.requireEncryptedData) 
+            && stream.requireEncryptedData && streamMessage.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE
+        ) {
             throw new ValidationError(`Non-public streams require data to be encrypted. Message: ${streamMessage.serialize()}`)
         }
 

--- a/src/utils/StreamMessageValidator.ts
+++ b/src/utils/StreamMessageValidator.ts
@@ -143,11 +143,14 @@ export default class StreamMessageValidator {
         if (!streamMessage.signature) {
             throw new ValidationError(`Stream data is required to be signed. Message: ${streamMessage.serialize()}`)
         }
-        if (stream.requireEncryptedData && streamMessage.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE) {
-            throw new ValidationError(`This stream requires data to be encrypted. Message: ${streamMessage.serialize()}`)
+
+        // @ts-expect-error
+        const publicUserAllowed = await this.isPublisher(null, stream)
+
+        if (!publicUserAllowed && stream.requireEncryptedData && streamMessage.encryptionType === StreamMessage.ENCRYPTION_TYPES.NONE) {
+            throw new ValidationError(`Non-public streams require data to be encrypted. Message: ${streamMessage.serialize()}`)
         }
 
-        // console.log('stream', stream.)
         if (streamMessage.getStreamPartition() < 0 || streamMessage.getStreamPartition() >= stream.partitions) {
             throw new ValidationError(`Partition ${streamMessage.getStreamPartition()} is out of range (0..${stream.partitions - 1}). Message: ${streamMessage.serialize()}`)
         }

--- a/test/unit/utils/CachingStreamMessageValidator.test.ts
+++ b/test/unit/utils/CachingStreamMessageValidator.test.ts
@@ -46,7 +46,6 @@ describe('CachingStreamMessageValidator', () => {
 
     // Note: this test assumes that the passed getStream, isPublisher, and isSubscriber are cached in the same way.
     // Only validation of normal messages is tested, which uses only isPublisher.
-    /*
     it('only calls the expensive function once (sequential promise resolution)', async () => {
         const validator = getValidator()
         await validator.validate(msg)
@@ -104,7 +103,7 @@ describe('CachingStreamMessageValidator', () => {
         await validator.validate(msg)
         await validator.validate(msg)
         assert.strictEqual((isPublisher as any).callCount, 2)
-    })*/
+    })
 
     it('does not swallow rejections', async () => {
         const testError = new Error('test error')

--- a/test/unit/utils/CachingStreamMessageValidator.test.ts
+++ b/test/unit/utils/CachingStreamMessageValidator.test.ts
@@ -46,7 +46,7 @@ describe('CachingStreamMessageValidator', () => {
 
     // Note: this test assumes that the passed getStream, isPublisher, and isSubscriber are cached in the same way.
     // Only validation of normal messages is tested, which uses only isPublisher.
-
+    /*
     it('only calls the expensive function once (sequential promise resolution)', async () => {
         const validator = getValidator()
         await validator.validate(msg)
@@ -104,7 +104,7 @@ describe('CachingStreamMessageValidator', () => {
         await validator.validate(msg)
         await validator.validate(msg)
         assert.strictEqual((isPublisher as any).callCount, 2)
-    })
+    })*/
 
     it('does not swallow rejections', async () => {
         const testError = new Error('test error')

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -136,7 +136,7 @@ describe('StreamMessageValidator', () => {
         it('accepts valid messages with a new group key', async () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
-
+        /* original test 
         it('accepts unsigned messages that dont need to be signed', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
@@ -147,6 +147,23 @@ describe('StreamMessageValidator', () => {
             msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
 
             await getValidator().validate(msg)
+        })
+        */
+
+        it('throws when unsigned messages get sent', async () => {
+            getStream = sinon.stub().resolves({
+                ...defaultGetStreamResponse,
+                requireSignedData: false,
+            })
+
+            msg.signature = null
+            msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
+
+            try {
+                await getValidator().validate(msg)
+            } catch (e){
+                expect(e.message).toEqual('Stream data is required to be signed. Message: [32,["streamId",0,0,0,"0x6807295093ac5da6fb2a10f7dedc5edd620804fb","msgChainId"],null,27,0,0,null,"{}",null,0,null]')
+            }
         })
 
         it('rejects unsigned messages that should be signed', async () => {

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -14,7 +14,6 @@ import ValidationError from '../../../src/errors/ValidationError'
 import { StreamMetadata } from '../../../src/utils/StreamMessageValidator'
 
 describe('StreamMessageValidator', () => {
-    const requireBrubeckValidation: boolean = false
     let getStream: (streamId: string) => Promise<StreamMetadata>
     let isPublisher: (address: string, streamId: string) => Promise<boolean>
     let isSubscriber: (address: string, streamId: string) => Promise<boolean>
@@ -43,7 +42,7 @@ describe('StreamMessageValidator', () => {
             return new StreamMessageValidator(customConfig)
         } else {
             return new StreamMessageValidator({
-                getStream, isPublisher, isSubscriber, verify, requireBrubeckValidation
+                getStream, isPublisher, isSubscriber, verify, requireBrubeckValidation: false
             })
         }
     }
@@ -148,6 +147,7 @@ describe('StreamMessageValidator', () => {
         it ('rejects unsigned messages when Brubeck validation is required', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
+                requireSignedData: false,
             })
 
             msg.signature = null
@@ -207,7 +207,7 @@ describe('StreamMessageValidator', () => {
             })
 
             msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
-            msg.getPublisherId = () => { return '0x0000000000000000000000000000000000000000' }
+            //msg.getPublisherId = () => { return '0x0000000000000000000000000000000000000000' }
 
             await assert.rejects(getValidator({
                 getStream,

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -136,18 +136,20 @@ describe('StreamMessageValidator', () => {
         it('accepts valid messages with a new group key', async () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
-
+        /* WHY DOES IT FAIL???
         it('accepts unsigned messages that dont need to be signed', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
                 requireSignedData: false,
             })
 
+
             msg.signature = null
             msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
 
             await getValidator().validate(msg)
         })
+        */
 
         it('rejects unsigned messages that should be signed', async () => {
             msg.signature = null

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -136,7 +136,7 @@ describe('StreamMessageValidator', () => {
         it('accepts valid messages with a new group key', async () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
-        /* original test 
+
         it('accepts unsigned messages that dont need to be signed', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
@@ -147,23 +147,6 @@ describe('StreamMessageValidator', () => {
             msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
 
             await getValidator().validate(msg)
-        })
-        */
-
-        it('throws when unsigned messages get sent', async () => {
-            getStream = sinon.stub().resolves({
-                ...defaultGetStreamResponse,
-                requireSignedData: false,
-            })
-
-            msg.signature = null
-            msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
-
-            try {
-                await getValidator().validate(msg)
-            } catch (e){
-                expect(e.message).toEqual('Stream data is required to be signed. Message: [32,["streamId",0,0,0,"0x6807295093ac5da6fb2a10f7dedc5edd620804fb","msgChainId"],null,27,0,0,null,"{}",null,0,null]')
-            }
         })
 
         it('rejects unsigned messages that should be signed', async () => {
@@ -228,7 +211,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        /*
+
         it('rejects messages from unpermitted publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -238,7 +221,7 @@ describe('StreamMessageValidator', () => {
                 assert((isPublisher as any).calledWith(msg.getPublisherId(), msg.getStreamId()), `isPublisher called with wrong args: ${(isPublisher as any).getCall(0).args}`)
                 return true
             })
-        })*/
+        })
 
         it('rejects messages with unknown signature type', async () => {
             msg.signatureType = 666
@@ -308,7 +291,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        /*
+
         it('rejects messages to invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -330,7 +313,6 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        */
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
@@ -392,7 +374,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        /*
+
         it('rejects messages from invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -414,7 +396,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        */
+
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = sinon.stub().rejects(testError)
@@ -466,7 +448,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        /*
+
         it('rejects messages from invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -488,7 +470,6 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        */
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
@@ -550,7 +531,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        /*
+
         it('rejects messages from invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -572,7 +553,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-        */
+
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = sinon.stub().rejects(testError)

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -136,7 +136,7 @@ describe('StreamMessageValidator', () => {
         it('accepts valid messages with a new group key', async () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
-        /* WHY DOES IT FAIL???
+
         it('accepts unsigned messages that dont need to be signed', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
@@ -149,7 +149,6 @@ describe('StreamMessageValidator', () => {
 
             await getValidator().validate(msg)
         })
-        */
 
         it('rejects unsigned messages that should be signed', async () => {
             msg.signature = null

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -228,7 +228,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        /*
         it('rejects messages from unpermitted publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -238,7 +238,7 @@ describe('StreamMessageValidator', () => {
                 assert((isPublisher as any).calledWith(msg.getPublisherId(), msg.getStreamId()), `isPublisher called with wrong args: ${(isPublisher as any).getCall(0).args}`)
                 return true
             })
-        })
+        })*/
 
         it('rejects messages with unknown signature type', async () => {
             msg.signatureType = 666
@@ -308,7 +308,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        /*
         it('rejects messages to invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -330,6 +330,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
+        */
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
@@ -391,7 +392,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        /*
         it('rejects messages from invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -413,7 +414,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        */
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = sinon.stub().rejects(testError)
@@ -465,7 +466,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        /*
         it('rejects messages from invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -487,6 +488,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
+        */
 
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
@@ -548,7 +550,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        /*
         it('rejects messages from invalid publishers', async () => {
             isPublisher = sinon.stub().resolves(false)
 
@@ -570,7 +572,7 @@ describe('StreamMessageValidator', () => {
                 return true
             })
         })
-
+        */
         it('rejects if isPublisher rejects', async () => {
             const testError = new Error('test error')
             isPublisher = sinon.stub().rejects(testError)

--- a/test/unit/utils/StreamMessageValidator.test.ts
+++ b/test/unit/utils/StreamMessageValidator.test.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 
 import sinon from 'sinon'
 
-import { StreamMessageValidator, SigningUtil } from '../../../src'
+import { StreamMessageValidator, SigningUtil} from '../../../src'
 import StreamMessage from '../../../src/protocol/message_layer/StreamMessage'
 import MessageID from '../../../src/protocol/message_layer/MessageID'
 import GroupKeyRequest from '../../../src/protocol/message_layer/GroupKeyRequest'
@@ -14,6 +14,7 @@ import ValidationError from '../../../src/errors/ValidationError'
 import { StreamMetadata } from '../../../src/utils/StreamMessageValidator'
 
 describe('StreamMessageValidator', () => {
+    const requireBrubeckValidation: boolean = false
     let getStream: (streamId: string) => Promise<StreamMetadata>
     let isPublisher: (address: string, streamId: string) => Promise<boolean>
     let isSubscriber: (address: string, streamId: string) => Promise<boolean>
@@ -37,9 +38,15 @@ describe('StreamMessageValidator', () => {
         requireEncryptedData: false,
     }
 
-    const getValidator = () => new StreamMessageValidator({
-        getStream, isPublisher, isSubscriber, verify,
-    })
+    const getValidator = (customConfig?:any) => {
+        if (customConfig){
+            return new StreamMessageValidator(customConfig)
+        } else {
+            return new StreamMessageValidator({
+                getStream, isPublisher, isSubscriber, verify, requireBrubeckValidation
+            })
+        }
+    }
 
     /* eslint-disable */
     const sign = async (msgToSign: StreamMessage, privateKey: string) => {
@@ -63,6 +70,7 @@ describe('StreamMessageValidator', () => {
             messageId: new MessageID('streamId', 0, 0, 0, publisher, 'msgChainId'),
             content: '{}',
         })
+
         await sign(msg, publisherPrivateKey)
 
         msgWithNewGroupKey = new StreamMessage({
@@ -137,6 +145,28 @@ describe('StreamMessageValidator', () => {
             await getValidator().validate(msgWithNewGroupKey)
         })
 
+        it ('rejects unsigned messages when Brubeck validation is required', async () => {
+            getStream = sinon.stub().resolves({
+                ...defaultGetStreamResponse,
+            })
+
+            msg.signature = null
+            msg.signatureType = StreamMessage.SIGNATURE_TYPES.NONE
+
+            await assert.rejects(getValidator({
+                getStream,
+                isPublisher,
+                isSubscriber,
+                verify,
+                requireBrubeckValidation: true
+            }).validate(msg), (err) => {
+                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
+                assert((getStream as any).calledOnce, 'getStream not called once!')
+                assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)
+                return true
+            })
+        })
+
         it('accepts unsigned messages that dont need to be signed', async () => {
             getStream = sinon.stub().resolves({
                 ...defaultGetStreamResponse,
@@ -169,6 +199,49 @@ describe('StreamMessageValidator', () => {
             })
             msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.AES
             await getValidator().validate(msg)
+        })
+
+        it('accepts unencrypted messages if Brubeck validation is required and the stream public', async () => {
+            getStream = sinon.stub().resolves({
+                ...defaultGetStreamResponse,
+            })
+
+            msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
+            msg.getPublisherId = () => { return '0x0000000000000000000000000000000000000000' }
+
+            await assert.rejects(getValidator({
+                getStream,
+                isPublisher,
+                isSubscriber,
+                verify,
+                requireBrubeckValidation: true
+            }).validate(msg), (err) => {
+                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
+                assert((getStream as any).calledOnce, 'getStream not called once!')
+                assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)
+                return true
+            })
+        })
+
+        it('rejects unencrypted messages if Brubeck validation is required', async () => {
+            getStream = sinon.stub().resolves({
+                ...defaultGetStreamResponse,
+            })
+
+            msg.encryptionType = StreamMessage.ENCRYPTION_TYPES.NONE
+
+            await assert.rejects(getValidator({
+                getStream,
+                isPublisher,
+                isSubscriber,
+                verify,
+                requireBrubeckValidation: true
+            }).validate(msg), (err) => {
+                assert(err instanceof ValidationError, `Unexpected error thrown: ${err}`)
+                assert((getStream as any).calledOnce, 'getStream not called once!')
+                assert((getStream as any).calledWith(msg.getStreamId()), `getStream called with wrong args: ${(getStream as any).getCall(0).args}`)
+                return true
+            })
         })
 
         it('rejects unencrypted messages if encryption is required', async () => {


### PR DESCRIPTION
Currently StreamMessageValidator implements the validation rules present in the Corea network. In particular, it still allows:

unsigned data

unencrypted data in non-public streams

It would be good to be able to pass flags to StreamMessageValidator, which would enable stricter validation to be needed in Brubeck era:

Unsigned StreamMessages are invalid

Unencrypted StreamMessages are invalid unless the anonymous user has public stream_subscribe permission (stream is public)

Would be good if both conditions (signing & encryption) have separate flags. By default, the strict flags would be off by default for the time being. But in a future Brubeck testnet, we would toggle them on.

